### PR TITLE
[SM-9252] Fix bug where we aren't adding new columns that we find in the latest schema

### DIFF
--- a/internal/migrator/diff.go
+++ b/internal/migrator/diff.go
@@ -111,6 +111,9 @@ func diffModels(columns []Column, model *dm.Model, dialect util.Dialect) (bool, 
 						FieldChanges: make([]FieldChange, 0),
 					}
 				}
+				if change.Action == NoAction {
+					change.Action = UpdateAction
+				}
 				change.FieldChanges = append(change.FieldChanges, FieldChange{
 					Action: AddAction,
 					Name:   field.Table,


### PR DESCRIPTION
Previous logic flow for diffModels function:

Loop 1: loop through all the columns of the table already stored in the customer's DB and compare it to the schema columns that we grab from nats. 
Loop 2: loop through all the columns of the schema we grabbed from nats and compare it to the columns already in the customer's DB table.

We were running into an issue where when iterating through that first full loop, we create a ModelChange variable and set the change action to NoAction. In that second loop, if we found a column that needed to be added, we'd add the column's info to the change variable, but the overall change action would still be "NoAction", meaning we wouldn't make any adjustments to the DB table. 

Logic flow now:
Initialize change variable before looping and set action to NoAction.
Do the 2 loops again, but change the change action to UpdateAction if see that a column needs to be added/or have its data type changed.