### PR TITLE
[SM-9338] Adding experimental fix for snowflake connector timing out

### DIFF
--- a/internal/provider/snowflake.go
+++ b/internal/provider/snowflake.go
@@ -14,6 +14,7 @@ import (
 	dm "github.com/shopmonkeyus/eds-server/internal/model"
 	"github.com/shopmonkeyus/eds-server/internal/util"
 	"github.com/shopmonkeyus/go-common/logger"
+	"github.com/snowflakedb/gosnowflake"
 	_ "github.com/snowflakedb/gosnowflake"
 )
 
@@ -50,7 +51,18 @@ func NewSnowflakeProvider(plogger logger.Logger, connString string, opts *Provid
 func (p *SnowflakeProvider) Start() error {
 	p.logger.Info("start")
 
-	db, err := sql.Open("snowflake", p.url)
+	//Testing whether there's an issue with the jdbc string we ask users to provide
+	snowflake_cfg, err := gosnowflake.ParseDSN(p.url)
+	if err != nil {
+		p.logger.Debug("failed to parse dsn. err: %v", err)
+		return err
+	}
+	dsn, err := gosnowflake.DSN(snowflake_cfg)
+	if err != nil {
+		p.logger.Debug("failed to convert config to dsn. err: %v", err)
+		return err
+	}
+	db, err := sql.Open("snowflake", dsn)
 	if err != nil {
 		p.logger.Error("unable to create connection: %w", err)
 	}


### PR DESCRIPTION
Functionally, gosnowflake seems to do this conversion under the hood (ie: if you give the snowflake driver a connection string, it'll convert it to a DSN Config and open a driver using that config), but I wanted to roll-out this fix as a sanity check. 

Here's the connection string produced by doing this conversion vs what we currently input:

Conversion- "loginCredentials@<organization_name>.snowflakecomputing.com:443?account=<organization_name>&client_session_keep_alive=true&database=<database>&ocspFailOpen=true&schema=<schema>&validateDefaultParameters=true&warehouse=<warehouse>"

Original- "loginCredentials@<organization_name>/<database>/<schema>?warehouse=<warehouse>&client_session_keep_alive=true"