### PR TITLE
[RBR-341] add workflow step for code signing

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,7 +23,8 @@ jobs:
       - name: End-to-end
         run: make e2e
   sign:
-    runs-on: austin
+    runs-on:
+      group: austin
     needs: build
     steps:
       - name: Import Code-Signing Certificates

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,3 +22,10 @@ jobs:
         run: go build -v ./...
       - name: End-to-end
         run: make e2e
+      - name: Import Code-Signing Certificates
+        uses: Apple-Actions/import-codesign-certs@v2
+        with:
+          # The certificates in a PKCS12 file encoded as a base64 string
+          p12-file-base64: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_P12_BASE64 }}
+          # The password used to import the PKCS12 file.
+          p12-password: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_PASSWORD }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,7 +23,7 @@ jobs:
       - name: End-to-end
         run: make e2e
   sign:
-    runs-on: macos-latest
+    runs-on: austin
     needs: build
     steps:
       - name: Import Code-Signing Certificates
@@ -37,3 +37,16 @@ jobs:
         run: |
           brew tap mitchellh/gon
           brew install mitchellh/gon/gon
+      - name: Build and code-sign the app
+        env:
+          CI: "true"
+          GIT_SHA: "${{ steps.sha.outputs.sha }}"
+          AC_PASSWORD: "${{ secrets.AC_PASSWORD }}"
+        run: |
+          gon --version
+          go run -tags sign . sign --dir ./output
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: output/*

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,8 +23,7 @@ jobs:
       - name: End-to-end
         run: make e2e
   sign:
-    runs-on:
-      group: austin
+    runs-on: macos-latest
     needs: build
     steps:
       - name: Import Code-Signing Certificates

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,6 +22,10 @@ jobs:
         run: go build -v ./...
       - name: End-to-end
         run: make e2e
+  sign:
+    runs-on: macos-latest
+    needs: build
+    steps:
       - name: Import Code-Signing Certificates
         uses: Apple-Actions/import-codesign-certs@v2
         with:
@@ -29,3 +33,7 @@ jobs:
           p12-file-base64: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_P12_BASE64 }}
           # The password used to import the PKCS12 file.
           p12-password: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_PASSWORD }}
+      - name: Install gon via HomeBrew for code signing and app notarization
+        run: |
+          brew tap mitchellh/gon
+          brew install mitchellh/gon/gon

--- a/cmd/sign.go
+++ b/cmd/sign.go
@@ -1,0 +1,210 @@
+//go:build sign
+// +build sign
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/k0kubun/go-ansi"
+	"github.com/shopmonkeyus/go-common/logger"
+	csys "github.com/shopmonkeyus/go-common/sys"
+	"github.com/spf13/cobra"
+)
+
+var builds = [][]string{
+	{"darwin", "arm64", "darwin-arm64"},
+	{"darwin", "amd64", "darwin-amd64"},
+	{"linux", "amd64", "linux-x64"},
+}
+
+func getGitSHA(ctx context.Context, logger logger.Logger) string {
+	thesha := os.Getenv("GIT_SHA")
+	if thesha != "" {
+		return thesha
+	}
+	c := exec.CommandContext(ctx, "git", "rev-parse", "--abbrev-ref", "HEAD")
+	buf, err := c.CombinedOutput()
+	if err != nil {
+		logger.Error("error running git: %s", err)
+		os.Exit(1)
+	}
+	branch := strings.TrimSpace(string(buf))
+	if branch == "main" {
+		c := exec.CommandContext(ctx, "git", "rev-parse", "origin/main")
+		buf, err := c.CombinedOutput()
+		if err != nil {
+			logger.Error("error running git rev-parse: %s", err)
+			os.Exit(1)
+		}
+		return strings.TrimSpace(string(buf))
+	}
+	// inside a PR, we need to go back one
+	c = exec.CommandContext(ctx, "git", "log", "--pretty=oneline", "-n", "2")
+	buf, err = c.CombinedOutput()
+	if err != nil {
+		logger.Error("error running git rev-parse: %s", err)
+		os.Exit(1)
+	}
+	lines := string(buf)
+	tokens := strings.Split(lines, "\n")
+	line := tokens[1]
+	return strings.TrimSpace(strings.Split(line, " ")[0])
+}
+
+func executeBuild(ctx context.Context, logger logger.Logger, goos string, arch string, name string, dest string, sha string) {
+	env := make([]string, len(os.Environ()))
+	copy(env, os.Environ())
+	env = append(env, "GOOS="+goos)
+	env = append(env, "GOARCH="+arch)
+	fn := path.Join(dest, name)
+	c := exec.CommandContext(ctx, "go", "build", "-ldflags", "-s -w -X 'github.com/shopmonkeyus/eds-server/cmd.Version="+sha+"'", "-o", fn)
+	c.Env = env
+	c.Stdin = os.Stdin
+	c.Stderr = os.Stderr
+	c.Stdout = io.Discard
+	if err := c.Run(); err != nil {
+		logger.Error("error running go build: %s", err)
+		os.Exit(1)
+	}
+	logger.Info("built: %s to %s", name, fn)
+}
+
+func executeLipo(ctx context.Context, logger logger.Logger, output string, a string, b string) {
+	cwd, _ := os.Getwd()
+	c := exec.CommandContext(ctx, "lipo", "-create", "-output", output, a, b)
+	c.Dir = cwd
+	c.Stdin = os.Stdin
+	c.Stderr = os.Stderr
+	c.Stdout = os.Stdout
+	if err := c.Run(); err != nil {
+		logger.Error("error running lipo: %s", err)
+		os.Exit(1)
+	}
+	logger.Info("created lipo at %s", output)
+}
+
+type teeWriter struct {
+	data strings.Builder
+}
+
+var _ io.Writer = (*teeWriter)(nil)
+
+func (w *teeWriter) Write(p []byte) (int, error) {
+	w.data.Write(p)
+	return os.Stdout.Write(p)
+}
+
+func exists(fn string) bool {
+	if _, err := os.Stat(fn); os.IsNotExist(err) {
+		return false
+	}
+	return true
+}
+
+func executeGon(ctx context.Context, logger logger.Logger, outdir string) {
+	cwd, _ := os.Getwd()
+	fn := path.Join(cwd, "sign.hcl")
+	if !exists(fn) {
+		logger.Error("file not found: %s", fn)
+		os.Exit(1)
+	}
+	if os.Getenv("CI") == "true" {
+		buf, err := os.ReadFile(fn)
+		if err != nil {
+			logger.Error("error reading fn: %s: %s", fn, err)
+			os.Exit(1)
+		}
+		s := strings.ReplaceAll(string(buf), `"./build/eds-server-darwin"`, `"`+path.Join(outdir, "eds-server-darwin")+`"`)
+		s = strings.ReplaceAll(s, "eds-server-darwin.zip", path.Join(cwd, "eds-server-darwin.zip"))
+		if err := os.WriteFile(fn, []byte(s), 0644); err != nil {
+			logger.Error("error writing fn: %s: %s", fn, err)
+			os.Exit(1)
+		}
+	}
+	cwd, _ = filepath.Abs(cwd)
+	os.Remove(path.Join(outdir, "eds-server-darwin-amd64"))
+	os.Remove(path.Join(outdir, "eds-server-darwin-arm64"))
+	started := time.Now()
+	logger.Info("Apple notarization requested ...")
+
+	var w teeWriter
+	c := exec.CommandContext(ctx, "gon", fn)
+	c.Dir = cwd
+	c.Env = os.Environ()
+	c.Stdin = os.Stdin
+	c.Stderr = os.Stderr
+	c.Stdout = &w
+	if err := c.Run(); err != nil {
+		logger.Error("error running gon: %s", err)
+		os.Exit(1)
+	}
+	if !strings.Contains(w.data.String(), "Notarization complete!") {
+		logger.Error("error performing notarization: %s", w.data.String())
+		os.Exit(1)
+	}
+	os.Remove(path.Join(outdir, "eds-server-darwin"))
+	os.Rename(path.Join(cwd, "eds-server-darwin.zip"), path.Join(outdir, "eds-server-darwin.zip"))
+
+	logger.Info("Apple notarization completed in %v", time.Since(started))
+}
+
+var signCmd = &cobra.Command{
+	Use:   "sign",
+	Short: "Code-signs binaries which includes cross platform binaries",
+	Run: func(cmd *cobra.Command, args []string) {
+		logger := logger.NewConsoleLogger()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		sha := getGitSHA(ctx, logger)
+		logger.Info("building binaries for sha: %s", sha)
+		outdir, _ := cmd.Flags().GetString("dir")
+		if outdir == "" {
+			tmpdir := os.TempDir()
+			outdir := path.Join(tmpdir, fmt.Sprintf("eds-server-build-%d", time.Now().Unix()))
+			defer os.RemoveAll(outdir)
+		}
+		outdir, _ = filepath.Abs(outdir)
+		os.MkdirAll(outdir, 0755)
+		var wg sync.WaitGroup
+		for _, build := range builds {
+			wg.Add(1)
+			goos := build[0]
+			arch := build[1]
+			suffix := build[2]
+			name := fmt.Sprintf("eds-server-%s", suffix)
+			go func() {
+				defer wg.Done()
+				executeBuild(ctx, logger, goos, arch, name, outdir, sha)
+			}()
+		}
+		go func() {
+			defer cancel()
+			<-csys.CreateShutdownChannel()
+			ansi.EraseInLine(3) // clear the CTRL+C break character
+		}()
+		wg.Wait()
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		executeLipo(ctx, logger, path.Join(outdir, "eds-server-darwin"), path.Join(outdir, "eds-server-darwin-arm64"), path.Join(outdir, "eds-server-darwin-amd64"))
+		executeGon(ctx, logger, outdir)
+
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(signCmd)
+	signCmd.Flags().String("dir", "./build", "the output directory")
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.21
 
 require (
 	github.com/jackc/pgx/v5 v5.5.1
+	github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213
 	github.com/microsoft/go-mssqldb v1.6.0
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db
 	github.com/schollz/progressbar/v3 v3.14.1
@@ -58,6 +59,7 @@ require (
 	github.com/klauspost/cpuid/v2 v2.2.6 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20231016141302-07b5767bb0ed // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8 // indirect
 	github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3 // indirect
 	github.com/mtibben/percent v0.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,7 @@ github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9Y
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
+github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213 h1:qGQQKEcAR99REcMpsXCp3lJ03zYT1PkRd3kQGPn9GVg=
 github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213/go.mod h1:vNUNkEQ1e29fT/6vq2aBdFsgNPmy8qMdSay1npru+Sw=
 github.com/klauspost/asmfmt v1.3.2 h1:4Ri7ox3EwapiOjCki+hw14RyKk201CN4rzyCJRFLpK4=
 github.com/klauspost/asmfmt v1.3.2/go.mod h1:AG8TuvYojzulgDAMCnYn50l/5QV3Bs/tp6j0HLHbNSE=
@@ -136,6 +137,7 @@ github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/lufia/plan9stats v0.0.0-20231016141302-07b5767bb0ed h1:036IscGBfJsFIgJQzlui7nK1Ncm0tp2ktmPj8xO4N/0=
 github.com/lufia/plan9stats v0.0.0-20231016141302-07b5767bb0ed/go.mod h1:ilwx/Dta8jXAgpFYFvSWEMwxmbWXyiUHkd5FwyKhb5k=
+github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/microsoft/go-mssqldb v1.6.0 h1:mM3gYdVwEPFrlg/Dvr2DNVEgYFG7L42l+dGc67NNNpc=
 github.com/microsoft/go-mssqldb v1.6.0/go.mod h1:00mDtPbeQCRGC1HwOOR5K/gr30P1NcEG0vx6Kbv2aJU=

--- a/sign.hcl
+++ b/sign.hcl
@@ -1,0 +1,15 @@
+source = ["./build/eds-server-darwin"]
+bundle_id = "io.shopmonkey.eds-server"
+
+apple_id {
+  username = "jhaynie@shopmonkey.io"
+  password = "@env:AC_PASSWORD"
+}
+
+sign {
+  application_identity = "Developer ID Application: Shopmonkey Inc. (VJTZ4HKFCU)"
+}
+
+zip {
+  output_path = "eds-server-darwin.zip"
+}


### PR DESCRIPTION
Steps to do:
1. Verify eds-server repo can access the mac-os runner group (https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/managing-access-to-self-hosted-runners-using-groups#changing-which-repositories-can-access-a-runner-group)
2. Verify that `secrets.APPLE_DEVELOPER_CERTIFICATE_P12_BASE64` and `secrets.APPLE_DEVELOPER_CERTIFICATE_PASSWORD` are reachable by eds-server (if these are org-level secrets, they *should* be, but if they're repo-level secrets, they won't be. These variable names were originally pulled from wrench).
3. Verify that the setting mentioned [here](https://github.com/orgs/community/discussions/62316#discussioncomment-6599115) is currently set (requiring approval of workflow to run for all outside collaborators)