### PR TITLE
[RBR-350] creating 1 NATS message processor for all of the providers rather than a separate NATS message processor for each provider

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,66 +36,76 @@ func mustFlagString(cmd *cobra.Command, name string, required bool) string {
 	return val
 }
 
-type ProviderFunc func(p internal.Provider) error
+type ProviderFunc func(p []internal.Provider) error
 
-func runProvider(logger logger.Logger, url string, dryRun bool, verbose bool, importer string, fn ProviderFunc, nc *nats.Conn) {
+func runProviders(logger logger.Logger, urls []string, dryRun bool, verbose bool, importer string, fn ProviderFunc, nc *nats.Conn) {
 	opts := &provider.ProviderOpts{
 		DryRun:   dryRun,
 		Verbose:  verbose,
 		Importer: importer,
 	}
-	provider, err := provider.NewProviderForURL(logger, url, opts)
-	if err != nil {
-		logger.Error("error creating provider: %s", err)
-		os.Exit(1)
-	}
-	if err := provider.Start(); err != nil {
-		logger.Error("error starting provider: %s", err)
-		os.Exit(1)
-	}
-	if importer != "" {
-		resp, err := http.Get(opts.Importer)
+	providers := []internal.Provider{}
+	for _, url := range urls {
+		provider, err := provider.NewProviderForURL(logger, url, opts)
 		if err != nil {
-			logger.Error("error from importer url request: %s", err)
+			logger.Error("error creating provider: %s", err)
 			os.Exit(1)
 		}
-		if resp.StatusCode != http.StatusOK {
-			logger.Error("invalid status code from importer url: %s", opts.Importer)
+		if err := provider.Start(); err != nil {
+			logger.Error("error starting provider: %s", err)
 			os.Exit(1)
 		}
-		defer resp.Body.Close()
-
-		gzReader, err := gzip.NewReader(resp.Body)
-		if err != nil {
-			logger.Error("error creating gzip reader: %s", err)
-			os.Exit(1)
-		}
-		scanner := bufio.NewScanner(gzReader)
-		const maxCapacity = 1024 * 1024
-		scanner.Buffer(make([]byte, maxCapacity), maxCapacity)
-
-		for scanner.Scan() {
-			data := scanner.Bytes()
-
-			err = provider.Import(data, nc)
+		if importer != "" {
+			resp, err := http.Get(opts.Importer)
 			if err != nil {
-				logger.Error("error importing data: %s", err)
+				logger.Error("error from importer url request: %s", err)
 				os.Exit(1)
 			}
+			if resp.StatusCode != http.StatusOK {
+				logger.Error("invalid status code from importer url: %s", opts.Importer)
+				os.Exit(1)
+			}
+			defer resp.Body.Close()
+
+			gzReader, err := gzip.NewReader(resp.Body)
+			if err != nil {
+				logger.Error("error creating gzip reader: %s", err)
+				os.Exit(1)
+			}
+			scanner := bufio.NewScanner(gzReader)
+			const maxCapacity = 1024 * 1024
+			scanner.Buffer(make([]byte, maxCapacity), maxCapacity)
+
+			for scanner.Scan() {
+				data := scanner.Bytes()
+
+				err = provider.Import(data, nc)
+				if err != nil {
+					logger.Error("error importing data: %s", err)
+					os.Exit(1)
+				}
+			}
+
+			logger.Info("Importing data instead of streaming")
+			os.Exit(1)
 		}
 
-		logger.Info("Importing data instead of streaming")
-		os.Exit(1)
+		providers = append(providers, provider)
 	}
-	ferr := fn(provider)
+
+	ferr := fn(providers)
 	if ferr != nil {
-		provider.Stop()
-		logger.Error("error: %s", ferr)
-		os.Exit(1)
+		for _, provider := range providers {
+			provider.Stop()
+			logger.Error("error: %s", ferr)
+			os.Exit(1)
+		}
 	}
-	if err := provider.Stop(); err != nil {
-		logger.Error("error stopping provider: %s", err)
-		os.Exit(1)
+	for _, provider := range providers {
+		if err := provider.Stop(); err != nil {
+			logger.Error("error stopping provider: %s", err)
+			os.Exit(1)
+		}
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -73,6 +73,7 @@ func runProviders(logger logger.Logger, urls []string, dryRun bool, verbose bool
 				os.Exit(1)
 			}
 			scanner := bufio.NewScanner(gzReader)
+			defer gzReader.Close()
 			const maxCapacity = 1024 * 1024
 			scanner.Buffer(make([]byte, maxCapacity), maxCapacity)
 
@@ -85,12 +86,13 @@ func runProviders(logger logger.Logger, urls []string, dryRun bool, verbose bool
 					os.Exit(1)
 				}
 			}
-
-			logger.Info("Importing data instead of streaming")
-			os.Exit(1)
 		}
 
 		providers = append(providers, provider)
+	}
+	if importer != "" {
+		logger.Info("Imported pre-signed URL data instead of streaming")
+		os.Exit(1)
 	}
 
 	ferr := fn(providers)

--- a/internal/provider/postgresql.go
+++ b/internal/provider/postgresql.go
@@ -34,7 +34,7 @@ var _ internal.Provider = (*PostgresProvider)(nil)
 
 func NewPostgresProvider(plogger logger.Logger, connString string, opts *ProviderOpts) (internal.Provider, error) {
 	logger := plogger.WithPrefix("[postgresql]")
-	logger.Info("starting postgres connection with connection string: ", util.MaskConnectionString(connString))
+	logger.Info("starting postgres connection with connection string: " + util.MaskConnectionString(connString))
 	ctx := context.Background()
 	return &PostgresProvider{
 		logger: logger,

--- a/internal/provider/postgresql.go
+++ b/internal/provider/postgresql.go
@@ -34,7 +34,7 @@ var _ internal.Provider = (*PostgresProvider)(nil)
 
 func NewPostgresProvider(plogger logger.Logger, connString string, opts *ProviderOpts) (internal.Provider, error) {
 	logger := plogger.WithPrefix("[postgresql]")
-	logger.Info("starting postgres connection with connection string: " + util.MaskConnectionString(connString))
+	logger.Info("starting postgres connection with connection string: %s", util.MaskConnectionString(connString))
 	ctx := context.Background()
 	return &PostgresProvider{
 		logger: logger,

--- a/internal/provider/snowflake.go
+++ b/internal/provider/snowflake.go
@@ -36,7 +36,7 @@ var _ internal.Provider = (*SnowflakeProvider)(nil)
 
 func NewSnowflakeProvider(plogger logger.Logger, connString string, opts *ProviderOpts) (internal.Provider, error) {
 	logger := plogger.WithPrefix("[snowflake]")
-	logger.Info("starting snowflake connection with connection string: " + util.MaskConnectionString(connString))
+	logger.Info("starting snowflake connection with connection string: %s", util.MaskConnectionString(connString))
 	schema, err := getSnowflakeSchema(connString)
 	if err != nil {
 		return nil, err

--- a/internal/provider/snowflake.go
+++ b/internal/provider/snowflake.go
@@ -36,7 +36,7 @@ var _ internal.Provider = (*SnowflakeProvider)(nil)
 
 func NewSnowflakeProvider(plogger logger.Logger, connString string, opts *ProviderOpts) (internal.Provider, error) {
 	logger := plogger.WithPrefix("[snowflake]")
-	logger.Info("starting snowflake connection with connection string: ", util.MaskConnectionString(connString))
+	logger.Info("starting snowflake connection with connection string: " + util.MaskConnectionString(connString))
 	schema, err := getSnowflakeSchema(connString)
 	if err != nil {
 		return nil, err

--- a/internal/provider/sqlserver.go
+++ b/internal/provider/sqlserver.go
@@ -34,7 +34,7 @@ var _ internal.Provider = (*SqlServerProvider)(nil)
 
 func NewSqlServerProvider(plogger logger.Logger, connString string, opts *ProviderOpts) (internal.Provider, error) {
 	logger := plogger.WithPrefix("[sqlserver]")
-	logger.Info("starting mssql plugin connection with connection string: ", util.MaskConnectionString(connString))
+	logger.Info("starting mssql plugin connection with connection string: " + util.MaskConnectionString(connString))
 	ctx := context.Background()
 	return &SqlServerProvider{
 		logger: logger,

--- a/internal/provider/sqlserver.go
+++ b/internal/provider/sqlserver.go
@@ -34,7 +34,7 @@ var _ internal.Provider = (*SqlServerProvider)(nil)
 
 func NewSqlServerProvider(plogger logger.Logger, connString string, opts *ProviderOpts) (internal.Provider, error) {
 	logger := plogger.WithPrefix("[sqlserver]")
-	logger.Info("starting mssql plugin connection with connection string: " + util.MaskConnectionString(connString))
+	logger.Info("starting mssql plugin connection with connection string: %s", util.MaskConnectionString(connString))
 	ctx := context.Background()
 	return &SqlServerProvider{
 		logger: logger,


### PR DESCRIPTION
Previously, in server.go, we would iterate through the connection string URLs provided in our args and create a NATS message processor for each connection string URL provided. This was causing NATS messages to be round-robinned between the providers, with a single provider acknowledging the NATS message before any other providers could access the message. 

In this change, we now create a single NATS message processor, with all of the providers pulling from this message processor and processing the message before we acknowledge the NATS message. 

Console logging showcasing that the same message is processed by both a postgresql provider and a sqlserver provider:
![image](https://github.com/shopmonkeyus/eds-server/assets/25914598/df45488b-c669-42f9-a245-c09802500429)
![image](https://github.com/shopmonkeyus/eds-server/assets/25914598/c67ccf75-258b-4cbc-ac28-ad4353819467)
