### PR TITLE
'@' chars in connection string passwords should not break masking

### DIFF
--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -156,7 +156,7 @@ func TryConvertJson(fieldType string, val interface{}) (interface{}, error) {
 }
 
 func MaskConnectionString(connectionString string) string {
-	re := regexp.MustCompile(`(.*://)(.*?:)(.*?)(@.*)`)
+	re := regexp.MustCompile(`(.*://)(.*?:)(.*)(@.*)`)
 	maskedConnectionString := re.ReplaceAllString(connectionString, "$1*****:*****$4")
 
 	return maskedConnectionString

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -37,7 +37,7 @@ func TestMaskConnectionString(t *testing.T) {
 		},
 		{
 			name:                     "Another Valid Sql Server Connection String",
-			originalConnectionString: "sqlserver://sqlUserName:passw..rd.a.!!!##@localhost:5432/shopmonkey?sslmode=disable",
+			originalConnectionString: "sqlserver://sqlUserName:p@ssw..rd.a.!!!##@localhost:5432/shopmonkey?sslmode=disable",
 			expectedMaskedString:     "sqlserver://*****:*****@localhost:5432/shopmonkey?sslmode=disable",
 		},
 		{


### PR DESCRIPTION
When using the `v2.1.1-rc` release, I noticed that our database password was not fully masked.  This ended up being caused by our password containing a `@` character and the masking regex was using lazy matching.  After swapping to greedy matching, passwords with `@` characters will now be fully masked.

The only future risk with this change would be if a value beyond the password contains an `@` character.  However, the effect of that would be that even more of the connection string would become masked which is not harmful.