### PR TITLE
[RBR-216] Adding leaf-node support for EDS

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/nats-io/nats.go"
 	"github.com/shopmonkeyus/eds-server/internal"
+	dm "github.com/shopmonkeyus/eds-server/internal/model"
 	"github.com/shopmonkeyus/eds-server/internal/provider"
 	"github.com/shopmonkeyus/eds-server/internal/util"
 	"github.com/shopmonkeyus/go-common/logger"
@@ -49,6 +50,7 @@ func runLocalProvider(logger logger.Logger, natsProvider internal.Provider, fn P
 			os.Exit(1)
 		}
 	}
+
 	for _, provider := range providers {
 		if err := provider.Stop(); err != nil {
 			logger.Error("error stopping provider: %s", err)
@@ -58,7 +60,7 @@ func runLocalProvider(logger logger.Logger, natsProvider internal.Provider, fn P
 
 }
 
-func runProviders(logger logger.Logger, urls []string, dryRun bool, verbose bool, importer string, fn ProviderFunc, nc *nats.Conn) {
+func runProviders(logger logger.Logger, urls []string, schemaModelCache *map[string]dm.Model, dryRun bool, verbose bool, importer string, fn ProviderFunc, nc *nats.Conn) {
 	opts := &provider.ProviderOpts{
 		DryRun:   dryRun,
 		Verbose:  verbose,
@@ -66,7 +68,7 @@ func runProviders(logger logger.Logger, urls []string, dryRun bool, verbose bool
 	}
 	providers := []internal.Provider{}
 	for _, url := range urls {
-		provider, err := provider.NewProviderForURL(logger, url, opts)
+		provider, err := provider.NewProviderForURL(logger, url, schemaModelCache, opts)
 		if err != nil {
 			logger.Error("error creating provider: %s", err)
 			os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/jackc/pgx/v5 v5.5.1
 	github.com/microsoft/go-mssqldb v1.6.0
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db
+	github.com/nats-io/nats-server/v2 v2.9.21
 	github.com/schollz/progressbar/v3 v3.14.1
 	github.com/shirou/gopsutil/v3 v3.23.11
 	github.com/shopmonkeyus/go-common v0.0.46
@@ -60,6 +61,7 @@ require (
 	github.com/lufia/plan9stats v0.0.0-20231016141302-07b5767bb0ed // indirect
 	github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8 // indirect
 	github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3 // indirect
+	github.com/minio/highwayhash v1.0.2 // indirect
 	github.com/mtibben/percent v0.2.1 // indirect
 	github.com/pierrec/lz4/v4 v4.1.19 // indirect
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect
@@ -80,6 +82,7 @@ require (
 	golang.org/x/sys v0.15.0 // indirect
 	golang.org/x/term v0.15.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
+	golang.org/x/time v0.3.0 // indirect
 	golang.org/x/tools v0.16.1 // indirect
 	golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -224,6 +224,7 @@ golang.org/x/net v0.19.0 h1:zTwKpTd2XuCqf8huc7Fo2iSy+4RHPd10s4KzeTnVr1c=
 golang.org/x/net v0.19.0/go.mod h1:CfAk/cbD4CthTvqiEl8NpboMuiuOYsAr/7NOjZJtv1U=
 golang.org/x/sync v0.5.0 h1:60k92dhOjHxJkrqnwsfl8KuaHbn/5dl0lUPUklKo3qE=
 golang.org/x/sync v0.5.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/sys v0.0.0-20190130150945-aca44879d564/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201204225414-ed752295db88/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/processor.go
+++ b/internal/processor.go
@@ -22,29 +22,29 @@ var emptyJSON = []byte("{}")
 const modelRequestTimeout = time.Duration(time.Second * 30)
 
 type MessageProcessor struct {
-	logger            logger.Logger
-	companyID         []string
-	providers         []Provider
-	conn              *nats.Conn
-	js                nats.JetStreamContext
-	subscriber        []snats.Subscriber
-	dumpMessagesDir   string
-	consumerPrefix    string
-	context           context.Context
-	cancel            context.CancelFunc
-	modelVersionCache *map[string]dm.Model
+	logger                  logger.Logger
+	companyID               []string
+	providers               []Provider
+	conn                    *nats.Conn
+	js                      nats.JetStreamContext
+	subscriber              []snats.Subscriber
+	dumpMessagesDir         string
+	consumerPrefix          string
+	context                 context.Context
+	cancel                  context.CancelFunc
+	schemaModelVersionCache *map[string]dm.Model
 }
 
 // MessageProcessorOpts is the options for the message processor
 type MessageProcessorOpts struct {
-	Logger            logger.Logger
-	CompanyID         []string
-	Providers         []Provider
-	NatsConnection    *nats.Conn
-	DumpMessagesDir   string
-	TraceNats         bool
-	ConsumerPrefix    string
-	ModelVersionCache *map[string]dm.Model
+	Logger                  logger.Logger
+	CompanyID               []string
+	Providers               []Provider
+	NatsConnection          *nats.Conn
+	DumpMessagesDir         string
+	TraceNats               bool
+	ConsumerPrefix          string
+	SchemaModelVersionCache *map[string]dm.Model
 }
 
 // NewMessageProcessor will create a new processor for a given customer id
@@ -74,16 +74,16 @@ func NewMessageProcessor(opts MessageProcessorOpts) (*MessageProcessor, error) {
 
 	context, cancel := context.WithCancel(context.Background())
 	processor := &MessageProcessor{
-		logger:            opts.Logger.WithPrefix("[nats]"),
-		companyID:         opts.CompanyID,
-		providers:         opts.Providers,
-		conn:              opts.NatsConnection,
-		dumpMessagesDir:   opts.DumpMessagesDir,
-		consumerPrefix:    opts.ConsumerPrefix,
-		js:                js,
-		context:           context,
-		cancel:            cancel,
-		modelVersionCache: opts.ModelVersionCache,
+		logger:                  opts.Logger.WithPrefix("[nats]"),
+		companyID:               opts.CompanyID,
+		providers:               opts.Providers,
+		conn:                    opts.NatsConnection,
+		dumpMessagesDir:         opts.DumpMessagesDir,
+		consumerPrefix:          opts.ConsumerPrefix,
+		js:                      js,
+		context:                 context,
+		cancel:                  cancel,
+		schemaModelVersionCache: opts.SchemaModelVersionCache,
 	}
 	return processor, nil
 }
@@ -127,7 +127,7 @@ func (p *MessageProcessor) callback(ctx context.Context, payload []byte, msg *na
 	modelVersionId := fmt.Sprintf("%s-%s", model, modelVersion)
 	p.logger.Trace("got modelVersionId for: %s %s %s for msgid: %s", modelVersionId, model, modelVersion, msgid)
 
-	currentModelVersion, found := (*p.modelVersionCache)[modelVersionId]
+	currentModelVersion, found := (*p.schemaModelVersionCache)[modelVersionId]
 
 	if found {
 		schema = currentModelVersion
@@ -150,7 +150,7 @@ func (p *MessageProcessor) callback(ctx context.Context, payload []byte, msg *na
 		schema = foundSchema.Data
 		if foundSchema.Success {
 			p.logger.Trace("got schema for: %s %v for msgid: %s", modelVersionId, foundSchema.Data, msgid)
-			(*p.modelVersionCache)[modelVersionId] = schema
+			(*p.schemaModelVersionCache)[modelVersionId] = schema
 		} else {
 			return fmt.Errorf("no schema found for for: %s %v for msgid: %s", modelVersionId, foundSchema.Data, msgid)
 		}

--- a/internal/provider/file.go
+++ b/internal/provider/file.go
@@ -23,19 +23,20 @@ var OK = "OK"
 var ERR = "ERR"
 
 type FileProvider struct {
-	logger  logger.Logger
-	cmd     *exec.Cmd
-	stdin   io.WriteCloser
-	stdout  io.ReadCloser
-	scanner *bufio.Scanner
-	verbose bool
-	once    sync.Once
+	logger           logger.Logger
+	cmd              *exec.Cmd
+	stdin            io.WriteCloser
+	stdout           io.ReadCloser
+	scanner          *bufio.Scanner
+	verbose          bool
+	once             sync.Once
+	schemaModelCache *map[string]dm.Model
 }
 
 var _ internal.Provider = (*FileProvider)(nil)
 
 // NewFileProvider returns a provider that will stream files to a folder provided in the url
-func NewFileProvider(plogger logger.Logger, cmd []string, opts *ProviderOpts) (internal.Provider, error) {
+func NewFileProvider(plogger logger.Logger, cmd []string, schemaModelCache *map[string]dm.Model, opts *ProviderOpts) (internal.Provider, error) {
 	logger := plogger.WithPrefix(fmt.Sprintf("[file] [%s]", cmd[0]))
 	logger.Info("file provider will execute program: %s", cmd[0])
 	if _, err := os.Stat(cmd[0]); os.IsNotExist(err) {
@@ -53,12 +54,13 @@ func NewFileProvider(plogger logger.Logger, cmd []string, opts *ProviderOpts) (i
 	}
 	scanner := bufio.NewScanner(stdout)
 	return &FileProvider{
-		logger:  logger,
-		cmd:     theCmd,
-		stdin:   stdin,
-		stdout:  stdout,
-		scanner: scanner,
-		verbose: opts.Verbose,
+		logger:           logger,
+		cmd:              theCmd,
+		stdin:            stdin,
+		stdout:           stdout,
+		scanner:          scanner,
+		verbose:          opts.Verbose,
+		schemaModelCache: schemaModelCache,
 	}, nil
 }
 

--- a/internal/provider/init.go
+++ b/internal/provider/init.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/shopmonkeyus/eds-server/internal"
+	dm "github.com/shopmonkeyus/eds-server/internal/model"
 	"github.com/shopmonkeyus/go-common/logger"
 )
 
@@ -31,7 +32,7 @@ type ProviderOpts struct {
 }
 
 // NewProviderForURL will return a new internal.Provider for the driver based on the url
-func NewProviderForURL(logger logger.Logger, urlstr string, opts *ProviderOpts) (internal.Provider, error) {
+func NewProviderForURL(logger logger.Logger, urlstr string, schemaModelVersionCache *map[string]dm.Model, opts *ProviderOpts) (internal.Provider, error) {
 
 	driver, u, err := parseURLForProvider(urlstr)
 	if err != nil {
@@ -47,17 +48,17 @@ func NewProviderForURL(logger logger.Logger, urlstr string, opts *ProviderOpts) 
 				args = append(args, v...)
 			}
 		}
-		return NewFileProvider(logger, args, opts)
+		return NewFileProvider(logger, args, schemaModelVersionCache, opts)
 	case "postgresql":
-		return NewPostgresProvider(logger, urlstr, opts)
+		return NewPostgresProvider(logger, urlstr, schemaModelVersionCache, opts)
 	case "sqlserver":
-		return NewSqlServerProvider(logger, urlstr, opts)
+		return NewSqlServerProvider(logger, urlstr, schemaModelVersionCache, opts)
 	case "snowflake":
 		urlstr, err := convertSnowflakeConnectionString(urlstr)
 		if err != nil {
 			return nil, err
 		}
-		return NewSnowflakeProvider(logger, urlstr, opts)
+		return NewSnowflakeProvider(logger, urlstr, schemaModelVersionCache, opts)
 
 	default:
 		return nil, fmt.Errorf("no suitable provider found for url: %s", urlstr)

--- a/internal/provider/nats.go
+++ b/internal/provider/nats.go
@@ -100,3 +100,15 @@ func (p *NatsProvider) Import(dataMap map[string]interface{}, tableName string, 
 func (p *NatsProvider) GetNatsConn() *nats.Conn {
 	return p.nc
 }
+
+func (p *NatsProvider) AddHealthCheck() error {
+	_, err := p.nc.Subscribe("health", func(msg *nats.Msg) {
+		p.nc.Publish(msg.Reply, []byte("I'm healthy"))
+	})
+	if err != nil {
+		err = fmt.Errorf("error subscribing to health subject: %v", err)
+		return err
+	}
+	p.logger.Info("NATS server is now listening for health check requests")
+	return nil
+}

--- a/internal/provider/nats.go
+++ b/internal/provider/nats.go
@@ -1,0 +1,109 @@
+package provider
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/nats-io/nats.go"
+	"github.com/shopmonkeyus/eds-server/internal/datatypes"
+	dm "github.com/shopmonkeyus/eds-server/internal/model"
+	"github.com/shopmonkeyus/go-common/logger"
+)
+
+type NatsProvider struct {
+	logger logger.Logger
+	nc     *nats.Conn
+	js     nats.JetStreamContext
+	opts   *ProviderOpts
+}
+
+func NewNatsProvider(logger logger.Logger, urlstring string, opts *ProviderOpts, remoteNc *nats.Conn) (*NatsProvider, error) {
+
+	streamConfigJSON, err := os.ReadFile("stream.conf")
+	if err != nil {
+		return nil, fmt.Errorf("1/2: unable to find and open stream config with error: %s", err)
+	}
+	streamConfig := nats.StreamConfig{}
+	err = json.Unmarshal([]byte(streamConfigJSON), &streamConfig)
+	if err != nil {
+		if e, ok := err.(*json.SyntaxError); ok {
+			logger.Error("syntax error at byte offset %d", e.Offset)
+		}
+		return nil, fmt.Errorf("2/2: unable to parse stream config with error: %s", err)
+	}
+
+	nc, err := nats.Connect(urlstring)
+	if err != nil {
+		return nil, fmt.Errorf("unable to connect to nats server: %s with error: %s", urlstring, err)
+	}
+
+	js, err := nc.JetStream()
+	if err != nil {
+		return nil, fmt.Errorf("unable to configure Jetstream: %s", err)
+	}
+
+	_, err = js.AddStream(&streamConfig)
+	if err != nil {
+		return nil, fmt.Errorf("unable to configure Jetstream: %s", err)
+	}
+
+	logger.Info("nats provider will publish to: %s", urlstring)
+	return &NatsProvider{
+		logger,
+		nc,
+		js,
+		opts,
+	}, nil
+}
+
+// Start the provider and return an error or nil if ok
+func (p *NatsProvider) Start() error {
+	return nil
+}
+
+// Stop the provider and return an error or nil if ok
+func (p *NatsProvider) Stop() error {
+	p.nc.Close()
+	return nil
+}
+
+// Process data received and return an error or nil if processed ok
+func (p *NatsProvider) Process(data datatypes.ChangeEventPayload, schema dm.Model) error {
+	location := "NONE"
+	if data.GetLocationID() != nil {
+		location = *data.GetLocationID()
+	}
+	companyId := *data.GetCompanyID()
+
+	subject := fmt.Sprintf("dbchange.%s.%s.%s.%s.PUBLIC.%d.%s", data.GetTable(), data.GetOperation(), companyId, location, data.GetVersion(), data.GetID())
+
+	p.logger.Debug(`Republish Message to: %s`, subject)
+
+	buf, err := json.MarshalIndent(data, "", " ")
+	if err != nil {
+		return err
+	}
+	_, err = p.js.Publish(subject, buf)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *NatsProvider) Import(toDO []byte, nc *nats.Conn) error {
+
+	p.js.Publish("FIX_SUBJECT", toDO)
+
+	return nil
+}
+
+func (p *NatsProvider) GetNatsConn() *nats.Conn {
+	return p.nc
+}
+
+// Migrate will tell the provider to do any migration work and return an error or nil if ok
+func (p *NatsProvider) Migrate() error {
+	return nil
+}

--- a/internal/provider/nats.go
+++ b/internal/provider/nats.go
@@ -92,18 +92,11 @@ func (p *NatsProvider) Process(data datatypes.ChangeEventPayload, schema dm.Mode
 	return nil
 }
 
-func (p *NatsProvider) Import(toDO []byte, nc *nats.Conn) error {
-
-	p.js.Publish("FIX_SUBJECT", toDO)
+func (p *NatsProvider) Import(dataMap map[string]interface{}, tableName string, nc *nats.Conn) error {
 
 	return nil
 }
 
 func (p *NatsProvider) GetNatsConn() *nats.Conn {
 	return p.nc
-}
-
-// Migrate will tell the provider to do any migration work and return an error or nil if ok
-func (p *NatsProvider) Migrate() error {
-	return nil
 }

--- a/internal/provider/sqlserver.go
+++ b/internal/provider/sqlserver.go
@@ -138,11 +138,9 @@ func (p *SqlServerProvider) Import(data []byte, nc *nats.Conn) error {
 
 	schema, schemaFound := p.schemaModelCache[tableName]
 	if !schemaFound {
-		schema, err = GetLatestSchema(p.logger, nc, tableName)
-		if err != nil {
-			return err
-		}
-		p.schemaModelCache[tableName] = schema
+		//Right now, the messaging provider connecting to our local server will not forward messages to the main server
+		//So we'll error out. Ideally we should always find the schema in the cache, so we shouldn't run into this code path
+		return errors.New("schema not found")
 	}
 
 	err = p.ensureTableSchema(schema)
@@ -188,9 +186,9 @@ func (p *SqlServerProvider) importSQL(data map[string]interface{}, m dm.Model) (
 
 		}
 	}
-
+	isFirstColumn := true
 	if shouldCreate {
-		for i, field := range m.Fields {
+		for _, field := range m.Fields {
 			// check if field is in payload
 			if _, ok := data[field.Name]; !ok {
 				continue
@@ -205,9 +203,11 @@ func (p *SqlServerProvider) importSQL(data map[string]interface{}, m dm.Model) (
 			}
 			values = append(values, val)
 
-			if i+1 < len(m.Fields) {
+			if !isFirstColumn {
 				sqlColumns.WriteString(",")
 				sqlValuePlaceHolder.WriteString(",")
+			} else {
+				isFirstColumn = false
 			}
 			columnCount += 1
 		}
@@ -272,9 +272,9 @@ func (p *SqlServerProvider) getSQL(c datatypes.ChangeEventPayload, m dm.Model) (
 
 			}
 		}
-
+		isFirstColumn := true
 		if shouldCreate {
-			for i, field := range m.Fields {
+			for _, field := range m.Fields {
 				// check if field is in payload
 				if _, ok := data[field.Name]; !ok {
 					continue
@@ -289,9 +289,11 @@ func (p *SqlServerProvider) getSQL(c datatypes.ChangeEventPayload, m dm.Model) (
 
 				values = append(values, val)
 
-				if i+1 < len(m.Fields) {
+				if !isFirstColumn {
 					sqlColumns.WriteString(",")
 					sqlValuePlaceHolder.WriteString(",")
+				} else {
+					isFirstColumn = false
 				}
 				columnCount += 1
 			}
@@ -303,8 +305,7 @@ func (p *SqlServerProvider) getSQL(c datatypes.ChangeEventPayload, m dm.Model) (
 			data := c.GetAfter()
 			p.logger.Debug("after object: %v", data)
 			columnCount := 1
-
-			for i, field := range m.Fields {
+			for _, field := range m.Fields {
 				// check if field is in payload since we do not drop columns automatically
 				if _, ok := data[field.Name]; !ok {
 					continue
@@ -322,8 +323,10 @@ func (p *SqlServerProvider) getSQL(c datatypes.ChangeEventPayload, m dm.Model) (
 				}
 
 				updateValues = append(updateValues, val)
-				if i+1 < len(m.Fields) {
+				if !isFirstColumn {
 					updateColumns.WriteString(",")
+				} else {
+					isFirstColumn = false
 				}
 				columnCount += 1
 			}

--- a/server.conf
+++ b/server.conf
@@ -1,0 +1,5 @@
+{
+    "port": 4223,
+    "max_connections": -1,
+    "jetstream": true
+}

--- a/stream.conf
+++ b/stream.conf
@@ -1,0 +1,20 @@
+{
+    "name": "dbchange",
+    "subjects": ["dbchange.>"],
+    "description": "dbchange stream for eds",
+    "max_consumers": -1,
+    "max_msgs": -1,
+    "max_bytes": -1,
+    "discard_new_per_subject": false,
+    "max_age": 604800000000000,
+    "max_msgs_per_subject": -1,
+    "max_msg_size": -1,
+    "num_replicas": 1,
+    "no_ack": false,
+    "duplicate_window": 86400000000000,
+    "sealed": false,
+    "deny_delete": false,
+    "deny_purge": false,
+    "allow_rollup_hdrs": false,
+    "storage": "file"
+}


### PR DESCRIPTION
Technical Details:
This spins up a local NATS server that our database providers now read from. Functionally, there are now 2 NATS messaging processors. The first one is still connected to our main Shopmonkey NATS, but looking at the dbchange stream. This messaging processor contains one provider (a NATS provider), which then republishes those dbchange messages to the local NATS server. The second NATS messaging processor is connected to our local NATS server, and will contain our database providers. 

The processors also share a schema model cache now. Previously, message processors would make a request if there was not a schema stored. Because of the shared schema model cache, the first message processor will make the schema request and the schema update will be shared by the other message processor. 

The importer also has some changes. Now, before processing all of the rows, we'll grab the latest schemas for the different tables that we'll be inserting into. 

Also a little bug fix related to how we generate the SQL for inserts/updates. 

Long-term Development Options:
With the changes above, there's some potential routes to go down. With the importer aspect, we can publish the rows as messages on the local NATS server, though we currently process the data without making use of NATS.

We can also have the schema requests come from our local NATS server and have it forwarded to the main NATS server, instead of having a shared schema model cache.

Business value: 
Just as a little example test, we can set-up a (currently local) health check. See picture below! 

This also opens up the possibility for better general observability if we wire up the local NATS server and grab metrics from it.

<img width="1023" alt="image" src="https://github.com/shopmonkeyus/eds-server/assets/25914598/8b898f28-5491-4bcc-a223-34cf1236e7e3">
