### PR TITLE
Fixing an issue that may be causing the file provider to become stuck

### DIFF
--- a/internal/provider/file.go
+++ b/internal/provider/file.go
@@ -92,7 +92,7 @@ func (p *FileProvider) readStout() error {
 	for p.scanner.Scan() {
 		line := p.scanner.Text()
 
-		switch p.scanner.Text() {
+		switch line {
 		case OK:
 			p.logger.Debug("success processing message")
 			return nil
@@ -100,7 +100,7 @@ func (p *FileProvider) readStout() error {
 			return fmt.Errorf("error processing message")
 		default:
 			if p.verbose {
-				p.logger.Debug(line)
+				p.logger.Debug("stdout read: %s", line)
 			}
 		}
 


### PR DESCRIPTION
We've encountered a case where the file provider is getting stuck extending messages again.

It appears that the `readStout` function is saving the result of `p.scanner.Text()` to a variable and then switching on `p.scanner.Text()` again.  While this shouldn't normally be a problem on its own, based on the image below the `OK` that our Python sends back was received and logged directly by eds-server and the only place I see that could occur is the default switch case.  And if correct, that would mean that the second call to `p.scanner.Text()` somehow resulted in a different value that was not `OK` or `ERR` because the default case logs the `line` variable, which contains the result of the first call to `p.scanner.Text()`

I am currently unsure how or where the scanner would be moved to the next token, but this change at least prevents this situation.

![Logged-OK](https://github.com/shopmonkeyus/eds-server/assets/142019302/17fef522-45fc-40c7-952b-c8f1d796020a)
