### PR TITLE
[RBR-1052] add header to republished nats message and update example to show header

### DIFF
--- a/examples/python/nats-provider.py
+++ b/examples/python/nats-provider.py
@@ -26,12 +26,13 @@ async def message_handler_wrapper(logger, msg):
 
 async def message_handler(logger, msg):
     subject = msg.subject
+    headers = msg.headers
     reply = msg.reply
     data = msg.data.decode()
     try:
         # Add your message handling logic here
         logger.info(f"Received a message on '{subject} {reply}': {data}")
-
+        logger.info(f"Received headers: {headers}")
         await msg.ack()  # Acknowledge the message to NATS so it doesn't get redelivered
     except Exception as e:
         logger.error(f"Error handling message: {e}")

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/shopmonkeyus/eds-server
 go 1.21
 
 require (
+	github.com/gorilla/mux v1.8.1
 	github.com/jackc/pgx/v5 v5.5.1
 	github.com/microsoft/go-mssqldb v1.6.0
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db
@@ -49,7 +50,6 @@ require (
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/flatbuffers v23.5.26+incompatible // indirect
-	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20231201235250-de7065d80cb9 // indirect

--- a/internal/datatypes/changeevent.go
+++ b/internal/datatypes/changeevent.go
@@ -58,6 +58,7 @@ type ChangeEventPayload interface {
 	GetDiff() []string
 	// // GetSQL gets the
 	// GetSQL(model dm.Model) (string, []interface{}, error)
+	GetMsgId() string
 }
 
 type ChangeEvent struct {
@@ -77,6 +78,7 @@ type ChangeEvent struct {
 	Before        map[string]interface{} `json:"before"`
 	After         map[string]interface{} `json:"after"`
 	Diff          []string               `json:"diff,omitempty"`
+	MsgId         string                 `json:"msgId,omitempty"`
 }
 
 var _ ChangeEventPayload = (*ChangeEvent)(nil)
@@ -148,6 +150,10 @@ func (c *ChangeEvent) GetAfter() map[string]interface{} {
 
 func (c *ChangeEvent) GetDiff() []string {
 	return c.Diff
+}
+
+func (c *ChangeEvent) GetMsgId() string {
+	return c.MsgId
 }
 
 func FromChangeEvent(buf []byte, gzip bool) (*ChangeEvent, error) {

--- a/internal/processor.go
+++ b/internal/processor.go
@@ -113,7 +113,7 @@ func (p *MessageProcessor) callback(ctx context.Context, payload []byte, msg *na
 		msg.AckSync()
 		return nil
 	}
-
+	data.MsgId = msgid
 	dumpFiles := p.dumpMessagesDir != ""
 	if dumpFiles {
 		ext := ".json"

--- a/internal/provider/nats.go
+++ b/internal/provider/nats.go
@@ -84,7 +84,11 @@ func (p *NatsProvider) Process(data datatypes.ChangeEventPayload, schema dm.Mode
 	if err != nil {
 		return err
 	}
-	_, err = p.js.Publish(subject, buf)
+	msg := nats.NewMsg(subject)
+	msg.Data = buf
+	msg.Header.Set(nats.MsgIdHdr, data.GetMsgId())
+
+	_, err = p.js.PublishMsg(msg)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This will add the Nats-Msg-Id to the re-published message:
![image](https://github.com/shopmonkeyus/eds-server/assets/25914598/5b2ee715-d0d6-47b6-941d-d80567275265)
