### PR TITLE
[RBR-1328] use timestamptz instead of timestamp_tz to match how we write sql type for snowflake

### DIFF
--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -172,7 +172,7 @@ func DetermineSnowflakeConversion(newType string) (string, error) {
 		return "TO_TIME", nil
 	case "timestamp":
 		return "TO_TIMESTAMP", nil
-	case "timestamp_ltz":
+	case "timestampltz":
 		return "TO_TIMESTAMP_LTZ", nil
 	case "timestamptz":
 		return "TO_TIMESTAMP_TZ", nil

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -174,7 +174,7 @@ func DetermineSnowflakeConversion(newType string) (string, error) {
 		return "TO_TIMESTAMP", nil
 	case "timestamp_ltz":
 		return "TO_TIMESTAMP_LTZ", nil
-	case "timestamp_tz":
+	case "timestamptz":
 		return "TO_TIMESTAMP_TZ", nil
 	case "variant", "string":
 		return "TO_VARIANT", nil


### PR DESCRIPTION
See: https://github.com/shopmonkeyus/eds-server/blob/main/internal/model/model.go#L205