### PR TITLE
[VCARB-61] Upload log file

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -421,8 +421,7 @@ var importCmd = &cobra.Command{
 		single, _ := cmd.Flags().GetBool("single")
 		dir := mustFlagString(cmd, "dir", false)
 
-		logger, closer := newLogger(cmd)
-		defer closer()
+		logger := newLogger(cmd)
 		logger = logger.WithPrefix("[import]")
 
 		dataDir := getDataDir(cmd, logger)

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -183,7 +183,7 @@ func sendEnd(logger logger.Logger, apiURL string, apiKey string, sessionId strin
 }
 
 func sendRenew(logger logger.Logger, apiURL string, apiKey string, sessionId string) (*string, error) {
-	req, err := http.NewRequest("POST", apiURL+"/v3/eds/renew/"+sessionId, strings.NewReader(util.JSONStringify(map[string]any{})))
+	req, err := http.NewRequest("POST", apiURL+"/v3/eds/renew/"+sessionId, strings.NewReader("{}"))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
 	}
@@ -251,6 +251,33 @@ func sendEndAndUpload(logger logger.Logger, apiurl string, apikey string, sessio
 	if errored {
 		logger.Info("error log files saved to %s for session: %s", logfile, sessionId)
 	}
+}
+
+func getUploadURL(logger logger.Logger, apiURL string, apiKey string, sessionId string) (string, error) {
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/v3/eds/%s/log", apiURL, sessionId), strings.NewReader("{}"))
+	if err != nil {
+		return "", fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+	setHTTPHeader(req, apiKey)
+	retry := util.NewHTTPRetry(req)
+	resp, err := retry.Do()
+	if err != nil {
+		return "", fmt.Errorf("failed to send session end: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		buf, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("failed to send session end. status code=%d. %s", resp.StatusCode, string(buf))
+	}
+	var s sessionEndResponse
+	if err := json.NewDecoder(resp.Body).Decode(&s); err != nil {
+		return "", fmt.Errorf("failed to decode response: %w", err)
+	}
+	if !s.Success {
+		return "", fmt.Errorf("failed to end session: %s", s.Message)
+	}
+	logger.Trace("session %s log url received: %s", sessionId, s.Data.URL)
+	return s.Data.URL, nil
 }
 
 var serverIgnoreFlags = map[string]bool{
@@ -438,8 +465,7 @@ var serverCmd = &cobra.Command{
 	Short: "Run the server",
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		logger, closer := newLogger(cmd)
-		closer()
+		logger := newLogger(cmd)
 
 		logger = logger.WithPrefix("[server]")
 
@@ -560,6 +586,53 @@ var serverCmd = &cobra.Command{
 			}
 		}
 
+		sendLogs := func() {
+			// TODO: lock this so we don't rotate the logs while we are uploading them!
+			logger.Info("server logfile requested")
+			if sessionId == "" {
+				logger.Error("no session ID to rotate logs")
+				return
+			}
+			resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/control/logfile", port))
+			if err != nil {
+				logger.Error("logfile failed: %s", err)
+				return
+			}
+			logger.Debug("logfile response: %d", resp.StatusCode)
+			if resp.StatusCode != http.StatusOK {
+				logger.Error("logfile failed: %d", resp.StatusCode)
+				return
+			}
+			defer resp.Body.Close()
+
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				logger.Error("failed to read body: %s", err)
+				return
+			}
+			logFile := string(buf)
+			logger.Debug("uploading logfile: %s", logFile)
+			// gzip the log file, do this first in case we get an error!
+			if err := util.GzipFile(logFile); err != nil {
+				logger.Error("failed to compress log file: %s", err)
+				return
+			}
+			compressedLogFile := logFile + ".gz"
+			defer os.Remove(compressedLogFile)
+			url, err := getUploadURL(logger, apiurl, apikey, sessionId)
+			if err != nil {
+				logger.Error("failed to get upload URL: %s", err)
+				return
+			}
+			if err := uploadLogs(logger, url, compressedLogFile); err != nil {
+				logger.Error("failed to upload logs to %s: %s", url, err)
+				return
+			}
+			// fork will be done writing to the file, so we can remove it
+			logger.Debug("removing old logfile: %s", logFile)
+			os.Remove(logFile)
+		}
+
 		natsurl := mustFlagString(cmd, "server", true)
 
 		// create a notification consumer that will listen for notification actions and handle them here
@@ -570,14 +643,25 @@ var serverCmd = &cobra.Command{
 			Pause:    pause,
 			Unpause:  unpause,
 			Upgrade:  upgrade,
+			SendLogs: sendLogs,
 		})
 
+		// setup tickers
+		duration, _ := cmd.Flags().GetDuration("renew-interval")
+		logger.Trace("will renew session every %v", duration)
+		renewTicker := time.NewTicker(duration)
+		logSenderTicker := time.NewTicker(time.Hour)
+		defer renewTicker.Stop()
+		defer logSenderTicker.Stop()
 		go func() {
 			defer util.RecoverPanic(logger)
-			duration, _ := cmd.Flags().GetDuration("renew-interval")
-			logger.Trace("will renew session every %v", duration)
-			for range time.Tick(duration) {
-				renew()
+			for {
+				select {
+				case <-logSenderTicker.C:
+					sendLogs()
+				case <-renewTicker.C:
+					renew()
+				}
 			}
 		}()
 
@@ -619,7 +703,6 @@ var serverCmd = &cobra.Command{
 				SaveLogs:         true,
 				WriteToStd:       true,
 				ForwardInterrupt: true,
-				LogFileSink:      true,
 				ProcessCallback:  processCallback,
 				Dir:              sessionDir,
 			})

--- a/internal/metrics.go
+++ b/internal/metrics.go
@@ -37,9 +37,9 @@ type SystemStats struct {
 		FlushDuration float64
 		PendingEvents float64
 		TotalEvents   float64
-	}
-	Memory *mem.VirtualMemoryStat
-	Load   *load.AvgStat
+	} `json:"metrics"`
+	Memory *mem.VirtualMemoryStat `json:"memory"`
+	Load   *load.AvgStat          `json:"load"`
 }
 
 // collect calls the function for each metric associated with the Collector

--- a/internal/notification/notification.go
+++ b/internal/notification/notification.go
@@ -29,11 +29,14 @@ type NotificationHandler struct {
 
 	// Upgrade action is called to upgrade the server version.
 	Upgrade func(version string, url string)
+
+	// SendLogs action is called to send logs to the server.
+	SendLogs func()
 }
 
 type Notification struct {
-	Action string         `json:"action"`
-	Data   map[string]any `json:"data,omitempty"`
+	Action string         `json:"action" msgpack:"action"`
+	Data   map[string]any `json:"data,omitempty" msgpack:"data,omitempty"`
 }
 
 func (n *Notification) String() string {
@@ -139,6 +142,8 @@ func (c *NotificationConsumer) callback(m *nats.Msg) {
 			return
 		}
 		c.handler.Upgrade(version, url)
+	case "sendlogs":
+		c.handler.SendLogs()
 	default:
 		c.logger.Warn("unknown action: %s", notification.Action)
 	}

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -4,7 +4,9 @@
 package util
 
 import (
+	"compress/gzip"
 	"fmt"
+	"io"
 	"os"
 	"syscall"
 )
@@ -36,4 +38,27 @@ func IsDirWritable(path string) (bool, error) {
 	}
 
 	return true, nil
+}
+
+func GzipFile(filepath string) error {
+	infile, err := os.Open(filepath)
+	if err != nil {
+		return fmt.Errorf("open: %w", err)
+	}
+	defer infile.Close()
+
+	outfile, err := os.Create(filepath + ".gz")
+	if err != nil {
+		return fmt.Errorf("create: %w", err)
+	}
+	defer outfile.Close()
+
+	zr := gzip.NewWriter(outfile)
+	defer zr.Close()
+	_, err = io.Copy(zr, infile)
+	if err != nil {
+		return fmt.Errorf("copy: %w", err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
Replaces `--log-file-sink` on `fork` with a logs dir inside the datadir and a smarter log sink that can `Rotate` whereby it switches writing to a new file and returns the completed previous log file. This can then be requested by the server via the http control plane. The server then gets control of the file, it compresses it, requests an upload url from Shopmonkey, uploads the file, and, on success, deletes it from disk. This assures that we dont run out of disk space for long-running servers.

Logs are automatically uploaded hourly. The server can be told to upload logs by publishing a notification with the action `sendlogs`.

`fork` merely exposes an ability to rotate the log and get back the last file, its up to `server` to manage rotations/uploads.


### other stuff
- the heartbeat payload was giant and mostly numeric so i swapped it to msgpack for a cool 2/3rds reduction in size (still logs as json).
- heartbeat/notification were missing some struct tags