### PR TITLE
[VCARB-94] - Added new enroll cmd

### DIFF
--- a/cmd/enroll.go
+++ b/cmd/enroll.go
@@ -80,7 +80,7 @@ var enrollCmd = &cobra.Command{
 			os.Mkdir("dataDir", 0755)
 		}
 
-		tokenFile := "dataDir/token.json"
+		tokenFile := filepath.Join("dataDir", "token.json")
 		file, err := os.Create(tokenFile)
 		if err != nil {
 			logger.Error("failed to create token file: %w", err)

--- a/cmd/enroll.go
+++ b/cmd/enroll.go
@@ -42,7 +42,6 @@ var enrollCmd = &cobra.Command{
 		logger = logger.WithPrefix("[enroll]")
 		code := mustFlagString(cmd, "code", true)
 
-		//get first letter of code
 		firstLetter := code[0:1]
 		apiURL, err := getApiUrl(firstLetter)
 
@@ -63,7 +62,6 @@ var enrollCmd = &cobra.Command{
 			os.Exit(1)
 		}
 		defer resp.Body.Close()
-
 		if resp.StatusCode != http.StatusOK {
 			buf, _ := io.ReadAll(resp.Body)
 			logger.Error("failed to enroll server. status code=%d. %s", resp.StatusCode, string(buf))
@@ -78,7 +76,9 @@ var enrollCmd = &cobra.Command{
 		if !enrollResp.Success {
 			logger.Error("failed to start enroll: %s", enrollResp.Message)
 		}
-		logger.Trace("session %s started successfully", enrollResp.Data.Token)
+		if _, err := os.Stat("dataDir"); os.IsNotExist(err) {
+			os.Mkdir("dataDir", 0755)
+		}
 
 		tokenFile := "dataDir/token.json"
 		file, err := os.Create(tokenFile)

--- a/cmd/enroll.go
+++ b/cmd/enroll.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -44,6 +45,7 @@ var enrollCmd = &cobra.Command{
 		logger = logger.WithPrefix("[enroll]")
 		code := args[0]
 		apiURL := mustFlagString(cmd, "api-url", false)
+		dataDir := getDataDir(cmd, logger)
 
 		if apiURL == "" {
 			logger.Debug("Getting api from prefix")
@@ -81,11 +83,8 @@ var enrollCmd = &cobra.Command{
 		if !enrollResp.Success {
 			logger.Error("failed to start enroll: %s", enrollResp.Message)
 		}
-		if _, err := os.Stat("dataDir"); os.IsNotExist(err) {
-			os.Mkdir("dataDir", 0755)
-		}
 
-		tokenFile := filepath.Join("dataDir", "token.json")
+		tokenFile := filepath.Join(dataDir, "token.json")
 		file, err := os.Create(tokenFile)
 		if err != nil {
 			logger.Error("failed to create token file: %w", err)
@@ -102,6 +101,12 @@ var enrollCmd = &cobra.Command{
 }
 
 func init() {
+	cwd, err := os.Getwd()
+	if err != nil {
+		fmt.Println("couldn't get current working directory: ", err)
+		os.Exit(1)
+	}
 	rootCmd.AddCommand(enrollCmd)
 	enrollCmd.Flags().String("api-url", "", "the for testing again preview environment")
+	enrollCmd.Flags().String("data-dir", cwd, "the data directory for storing logs and other data")
 }

--- a/cmd/enroll.go
+++ b/cmd/enroll.go
@@ -14,7 +14,8 @@ import (
 )
 
 type enrollTokenData struct {
-	Token string `json:"token"`
+	Token    string `json:"token"`
+	ServerID string `json:"serverId"`
 }
 
 type enrollResponse struct {
@@ -87,12 +88,15 @@ var enrollCmd = &cobra.Command{
 		if err != nil {
 			logger.Fatal("failed to create token file: %w", err)
 		}
-		_, err = file.WriteString(enrollResp.Data.Token)
+		jsonData, _ := json.Marshal(enrollResp.Data)
+		if err != nil {
+			logger.Fatal("Error converting to JSON: %v", err)
+		}
+		_, err = file.WriteString(string(jsonData))
 		if err != nil {
 			logger.Fatal("failed to write to token file: %w", err)
 		}
 		file.Close()
-
 	},
 }
 

--- a/cmd/enroll.go
+++ b/cmd/enroll.go
@@ -1,0 +1,103 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+type enrollTokenData struct {
+	Token string `json:"token"`
+}
+
+type enrollResponse struct {
+	Success bool            `json:"success"`
+	Message string          `json:"message"`
+	Data    enrollTokenData `json:"data"`
+}
+
+func getApiUrl(firstLetter string) (*string, error) {
+	apiUrls := map[string]string{
+		"P": "https://api.shopmonkey.cloud/",
+		"S": "https://sandbox-api.shopmonkey.cloud/",
+		"E": "https://edge-api.shopmonkey.cloud/",
+		"L": "http://localhost:3101",
+	}
+
+	if url, exists := apiUrls[firstLetter]; exists {
+		return &url, nil
+	}
+	return nil, fmt.Errorf("Invalid first letter")
+}
+
+var enrollCmd = &cobra.Command{
+	Use:   "enroll",
+	Short: "Enroll a new server and get api key",
+	Run: func(cmd *cobra.Command, args []string) {
+		logger := newLogger(cmd)
+		logger = logger.WithPrefix("[enroll]")
+		code := mustFlagString(cmd, "code", true)
+
+		//get first letter of code
+		firstLetter := code[0:1]
+		apiURL, err := getApiUrl(firstLetter)
+
+		if err != nil {
+			logger.Error("error getting api url: %s", err)
+			os.Exit(1)
+		}
+
+		req, err := http.NewRequest("GET", *apiURL+"/v3/eds/internal/enroll/"+code, nil)
+		if err != nil {
+			logger.Error("error creating request: %s", err)
+			os.Exit(1)
+
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			logger.Error("failed to enroll server: %w", err)
+			os.Exit(1)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			buf, _ := io.ReadAll(resp.Body)
+			logger.Error("failed to enroll server. status code=%d. %s", resp.StatusCode, string(buf))
+			os.Exit(1)
+		}
+
+		var enrollResp enrollResponse
+		if err := json.NewDecoder(resp.Body).Decode(&enrollResp); err != nil {
+			logger.Error("failed to decode response: %w", err)
+			os.Exit(1)
+		}
+		if !enrollResp.Success {
+			logger.Error("failed to start enroll: %s", enrollResp.Message)
+		}
+		logger.Trace("session %s started successfully", enrollResp.Data.Token)
+
+		tokenFile := "dataDir/token.json"
+		file, err := os.Create(tokenFile)
+		if err != nil {
+			logger.Error("failed to create token file: %w", err)
+			os.Exit(1)
+		}
+		_, err = file.WriteString(enrollResp.Data.Token)
+		if err != nil {
+			logger.Error("failed to write to token file: %w", err)
+			os.Exit(1)
+		}
+		defer file.Close()
+
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(enrollCmd)
+	enrollCmd.Flags().String("code", "", "the enrollment code from HQ")
+
+}

--- a/cmd/enroll.go
+++ b/cmd/enroll.go
@@ -31,7 +31,7 @@ func getApiUrl(firstLetter string) (*string, error) {
 	if url, exists := apiUrls[firstLetter]; exists {
 		return &url, nil
 	}
-	return nil, fmt.Errorf("Invalid first letter")
+	return nil, errors.New("Invalid first letter")
 }
 
 var enrollCmd = &cobra.Command{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -173,7 +173,7 @@ func getDataDir(cmd *cobra.Command, logger logger.Logger) string {
 	dataDir, _ = filepath.Abs(filepath.Clean(dataDir))
 
 	if !util.Exists(dataDir) {
-		os.Mkdir(dataDir, 0700)
+		os.MkdirAll(dataDir, 0700)
 		logger.Debug("making data directory: %s", dataDir)
 	}
 	if ok, err := util.IsDirWritable(dataDir); !ok {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -173,7 +173,7 @@ func getDataDir(cmd *cobra.Command, logger logger.Logger) string {
 	dataDir, _ = filepath.Abs(filepath.Clean(dataDir))
 
 	if !util.Exists(dataDir) {
-		os.Mkdir(dataDir, 0755)
+		os.Mkdir(dataDir, 0700)
 		logger.Debug("making data directory: %s", dataDir)
 	}
 	if ok, err := util.IsDirWritable(dataDir); !ok {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -173,7 +173,8 @@ func getDataDir(cmd *cobra.Command, logger logger.Logger) string {
 	dataDir, _ = filepath.Abs(filepath.Clean(dataDir))
 
 	if !util.Exists(dataDir) {
-		logger.Fatal("data directory %s does not exist. please create the directory and retry again.", dataDir)
+		os.Mkdir(dataDir, 0755)
+		logger.Debug("making data directory: %s", dataDir)
 	}
 	if ok, err := util.IsDirWritable(dataDir); !ok {
 		logger.Fatal("%s", err)

--- a/internal/util/zip.go
+++ b/internal/util/zip.go
@@ -1,0 +1,31 @@
+package util
+
+import (
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+)
+
+func GzipFile(filepath string) error {
+	infile, err := os.Open(filepath)
+	if err != nil {
+		return fmt.Errorf("open: %w", err)
+	}
+	defer infile.Close()
+
+	outfile, err := os.Create(filepath + ".gz")
+	if err != nil {
+		return fmt.Errorf("create: %w", err)
+	}
+	defer outfile.Close()
+
+	zr := gzip.NewWriter(outfile)
+	defer zr.Close()
+	_, err = io.Copy(zr, infile)
+	if err != nil {
+		return fmt.Errorf("copy: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
https://www.loom.com/share/9dc0a348851d4a1f8305b6c9c227e673


Testing:
- run this backend branch locally https://github.com/shopmonkeyus/backend/pull/7018
- Create a server in postman pointed at your local env
- Grab the `code`
- example: go run . enroll --code {code} --api-url https://api-de35bc.shopmonkey.cloud
