### PR TITLE
[VCARB-108] [VCARB-71] [VCARB-57] [VCARB-56] Import support for Kafka, EventHub and S3 and refactored for reuse

### DIFF
--- a/cmd/enroll.go
+++ b/cmd/enroll.go
@@ -25,9 +25,9 @@ type enrollResponse struct {
 
 func getAPIURL(firstLetter string) (*string, error) {
 	apiUrls := map[string]string{
-		"P": "https://api.shopmonkey.cloud/",
-		"S": "https://sandbox-api.shopmonkey.cloud/",
-		"E": "https://edge-api.shopmonkey.cloud/",
+		"P": "https://api.shopmonkey.cloud",
+		"S": "https://sandbox-api.shopmonkey.cloud",
+		"E": "https://edge-api.shopmonkey.cloud",
 		"L": "http://localhost:3101",
 	}
 

--- a/cmd/enroll.go
+++ b/cmd/enroll.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -71,8 +70,7 @@ var enrollCmd = &cobra.Command{
 		}
 		defer resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
-			buf, _ := io.ReadAll(resp.Body)
-			logger.Fatal("failed to enroll server. status code=%d. %s", resp.StatusCode, string(buf))
+			logger.Fatal("%s", handleAPIError(resp, "enroll"))
 		}
 
 		var enrollResp enrollResponse

--- a/cmd/enroll.go
+++ b/cmd/enroll.go
@@ -106,5 +106,6 @@ func init() {
 	}
 	rootCmd.AddCommand(enrollCmd)
 	enrollCmd.Flags().String("api-url", "", "the for testing again preview environment")
+	enrollCmd.Flags().MarkHidden("api-url")
 	enrollCmd.Flags().String("data-dir", cwd, "the data directory for storing logs and other data")
 }

--- a/cmd/fork.go
+++ b/cmd/fork.go
@@ -284,7 +284,7 @@ func init() {
 	forkCmd.Flags().String("creds", "", "the server credentials file provided by Shopmonkey")
 	forkCmd.Flags().String("server", "", "the nats server url, could be multiple comma separated")
 	forkCmd.Flags().String("url", "", "driver connection string")
-	forkCmd.Flags().String("api-url", "https://api.shopmonkey.cloud", "url to shopmonkey api")
+	forkCmd.Flags().String("api-url", "", "url to shopmonkey api")
 	forkCmd.Flags().Int("maxAckPending", defaultMaxAckPending, "the number of max ack pending messages")
 	forkCmd.Flags().Int("maxPendingBuffer", defaultMaxPendingBuffer, "the maximum number of messages to pull from nats to buffer")
 	forkCmd.Flags().Bool("restart", false, "restart the consumer from the beginning (only works on new consumers)")

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -433,7 +433,14 @@ var importCmd = &cobra.Command{
 
 		if cmd.Flags().Changed("api-url") {
 			logger.Info("using alternative API url: %s", apiURL)
+		} else {
+			url, err := util.GetAPIURLFromJWT(apiKey)
+			if err != nil {
+				logger.Fatal("invalid API key. %s", err)
+			}
+			apiURL = url
 		}
+
 		var err error
 
 		// load the schema from the api fresh

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -366,29 +366,25 @@ var importCmd = &cobra.Command{
 
 		logger := newLogger(cmd)
 		logger = logger.WithPrefix("[import]")
+		defer util.RecoverPanic(logger)
 
 		dataDir := getDataDir(cmd, logger)
 		schemaFile, _ := getSchemaAndTableFiles(dataDir)
 
 		if !dryRun && !noconfirm {
 
-			u, err := url.Parse(driverUrl)
+			meta, err := internal.GetDriverMetadataForURL(driverUrl)
 			if err != nil {
-				logger.Fatal("error parsing url: %s", err)
+				logger.Fatal("error getting driver metadata: %s", err)
 			}
 
-			// present a nicer looking provider
-			name := u.Scheme
-			if u.Path != "" {
-				name = name + ":" + u.Path[1:]
-			}
 			var confirmed bool
 			form := huh.NewForm(
 				huh.NewGroup(
 					huh.NewNote().
 						Title("\n🚨 WARNING 🚨"),
 					huh.NewConfirm().
-						Title(fmt.Sprintf("YOU ARE ABOUT TO DELETE EVERYTHING IN %s", name)).
+						Title(fmt.Sprintf("YOU ARE ABOUT TO DELETE EVERYTHING IN %s", meta.Name)).
 						Affirmative("Confirm").
 						Negative("Cancel").
 						Value(&confirmed),

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -552,6 +552,16 @@ var serverCmd = &cobra.Command{
 		server := mustFlagString(cmd, "server", true)
 		dataDir := getDataDir(cmd, logger)
 
+		if cmd.Flags().Changed("api-url") {
+			logger.Info("using alternative API url: %s", apiurl)
+		} else {
+			url, err := util.GetAPIURLFromJWT(apikey)
+			if err != nil {
+				logger.Fatal("invalid API key. %s", err)
+			}
+			apiurl = url
+		}
+
 		var credsFile string
 		var sessionDir string
 

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -149,8 +149,7 @@ func sendStart(logger logger.Logger, apiURL string, apiKey string, driverUrl str
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		buf, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("failed to send session start. status code=%d. %s", resp.StatusCode, string(buf))
+		return nil, handleAPIError(resp, "session start")
 	}
 	var sessionResp sessionStartResponse
 	if err := json.NewDecoder(resp.Body).Decode(&sessionResp); err != nil {
@@ -180,8 +179,7 @@ func sendEnd(logger logger.Logger, apiURL string, apiKey string, sessionId strin
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		buf, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("failed to send session end. status code=%d. %s", resp.StatusCode, string(buf))
+		return nil, handleAPIError(resp, "session end")
 	}
 	var s sessionEndResponse
 	if err := json.NewDecoder(resp.Body).Decode(&s); err != nil {
@@ -221,8 +219,7 @@ func sendRenew(logger logger.Logger, apiURL string, apiKey string, sessionId str
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		buf, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("failed to send session end. status code=%d. %s", resp.StatusCode, string(buf))
+		return nil, handleAPIError(resp, "session renew")
 	}
 	var s sessionRenewResponse
 	if err := json.NewDecoder(resp.Body).Decode(&s); err != nil {
@@ -253,9 +250,8 @@ func uploadFile(logger logger.Logger, url string, logFileBundle string) error {
 		return fmt.Errorf("failed to upload logs: %w", err)
 	}
 	defer resp.Body.Close()
-	buf, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to upload logs. status code=%d. %s", resp.StatusCode, string(buf))
+		return handleAPIError(resp, "upload logs")
 	}
 	logger.Trace("logs uploaded successfully: %s", logFileBundle)
 	return nil
@@ -340,8 +336,7 @@ func getLogUploadURL(logger logger.Logger, apiURL string, apiKey string, session
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		buf, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("failed to get log upload url. status code=%d. %s", resp.StatusCode, string(buf))
+		return "", handleAPIError(resp, "log upload url")
 	}
 	var s sessionEndResponse
 	if err := json.NewDecoder(resp.Body).Decode(&s); err != nil {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -42,3 +42,19 @@ services:
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+  init-kafka:
+    image: confluentinc/cp-kafka:7.7.0
+    depends_on:
+      - kafka
+    entrypoint: ["/bin/sh", "-c"]
+    command: |
+      "
+      # blocks until kafka is reachable
+      kafka-topics --bootstrap-server kafka:9092 --list
+
+      echo -e 'Creating kafka topics'
+      kafka-topics --bootstrap-server kafka:9092 --create --if-not-exists --topic eds --replication-factor 1 --partitions 1
+
+      echo -e 'Successfully created the following topics:'
+      kafka-topics --bootstrap-server kafka:9092 --list
+      "

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/fatih/color v1.17.0
 	github.com/go-sql-driver/mysql v1.8.1
+	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/google/uuid v1.6.0
 	github.com/lib/pq v1.10.9
 	github.com/nats-io/jwt/v2 v2.5.8
@@ -83,7 +84,6 @@ require (
 	github.com/goccy/go-json v0.10.3 // indirect
 	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/flatbuffers v24.3.25+incompatible // indirect
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect

--- a/go.sum
+++ b/go.sum
@@ -243,8 +243,6 @@ github.com/savsgio/gotils v0.0.0-20240704082632-aef3928b8a38 h1:D0vL7YNisV2yqE55
 github.com/savsgio/gotils v0.0.0-20240704082632-aef3928b8a38/go.mod h1:sM7Mt7uEoCeFSCBM+qBrqvEo+/9vdmj19wzp3yzUhmg=
 github.com/segmentio/kafka-go v0.4.47 h1:IqziR4pA3vrZq7YdRxaT3w1/5fvIH5qpCwstUanQQB0=
 github.com/segmentio/kafka-go v0.4.47/go.mod h1:HjF6XbOKh0Pjlkr5GVZxt6CsjjwnmhVOfURM5KMd8qg=
-github.com/shirou/gopsutil/v4 v4.24.6 h1:9qqCSYF2pgOU+t+NgJtp7Co5+5mHF/HyKBUckySQL64=
-github.com/shirou/gopsutil/v4 v4.24.6/go.mod h1:aoebb2vxetJ/yIDZISmduFvVNPHqXQ9SEJwRXxkf0RA=
 github.com/shirou/gopsutil/v4 v4.24.7 h1:V9UGTK4gQ8HvcnPKf6Zt3XHyQq/peaekfxpJ2HSocJk=
 github.com/shirou/gopsutil/v4 v4.24.7/go.mod h1:0uW/073rP7FYLOkvxolUQM5rMOLTNmRXnFKafpb71rw=
 github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=

--- a/internal/consumer/consumer.go
+++ b/internal/consumer/consumer.go
@@ -163,8 +163,10 @@ func (c *Consumer) flush() bool {
 		internal.PendingEvents.Dec()
 		count++
 	}
-	processingDuration := time.Since(*c.pendingStarted)
-	internal.ProcessingDuration.Observe(processingDuration.Seconds())
+	if c.pendingStarted != nil {
+		processingDuration := time.Since(*c.pendingStarted)
+		internal.ProcessingDuration.Observe(processingDuration.Seconds())
+	}
 	internal.FlushDuration.Observe(time.Since(started).Seconds())
 	internal.FlushCount.Observe(count)
 	c.pending = nil

--- a/internal/dbchange.go
+++ b/internal/dbchange.go
@@ -19,6 +19,8 @@ type DBChangeEvent struct {
 	Timestamp     int64           `json:"timestamp"`
 	MVCCTimestamp string          `json:"mvccTimestamp"`
 
+	Imported bool `json:"imported"` // NOTE: this is not on the real dbchange but added during import
+
 	object map[string]any
 }
 

--- a/internal/dbchange.go
+++ b/internal/dbchange.go
@@ -49,6 +49,15 @@ func (c *DBChangeEvent) GetObject() (map[string]any, error) {
 			c.object = res
 		}
 		return c.object, nil
+	} else if c.Before != nil {
+		if c.object == nil {
+			res := make(map[string]any)
+			if err := json.Unmarshal(c.Before, &res); err != nil {
+				return nil, err
+			}
+			c.object = res
+		}
+		return c.object, nil
 	}
 	return nil, nil
 }

--- a/internal/drivers/eventhub/eventhub.go
+++ b/internal/drivers/eventhub/eventhub.go
@@ -32,6 +32,7 @@ var _ internal.DriverLifecycle = (*eventHubDriver)(nil)
 var _ internal.DriverHelp = (*eventHubDriver)(nil)
 var _ importer.Handler = (*eventHubDriver)(nil)
 var _ internal.Importer = (*eventHubDriver)(nil)
+var _ internal.ImporterHelp = (*eventHubDriver)(nil)
 
 func (p *eventHubDriver) connect(urlString string) error {
 	u, err := url.Parse(urlString)

--- a/internal/drivers/eventhub/eventhub.go
+++ b/internal/drivers/eventhub/eventhub.go
@@ -57,7 +57,7 @@ func (p *eventHubDriver) Start(pc internal.DriverConfig) error {
 	p.logger = pc.Logger.WithPrefix("[eventhub]")
 
 	if err := p.connect(pc.URL); err != nil {
-		return nil
+		return err
 	}
 
 	p.logger.Info("started")
@@ -241,6 +241,11 @@ func (p *eventHubDriver) Import(config internal.ImporterConfig) error {
 	p.importConfig = config
 	p.batcher = util.NewBatcher()
 	return importer.Run(p.logger, config, p)
+}
+
+// SupportsDelete returns true if the importer supports deleting data.
+func (p *eventHubDriver) SupportsDelete() bool {
+	return false
 }
 
 func init() {

--- a/internal/drivers/eventhub/eventhub.go
+++ b/internal/drivers/eventhub/eventhub.go
@@ -9,30 +9,32 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs"
 	"github.com/shopmonkeyus/eds-server/internal"
+	"github.com/shopmonkeyus/eds-server/internal/importer"
 	"github.com/shopmonkeyus/eds-server/internal/util"
 	"github.com/shopmonkeyus/go-common/logger"
 )
 
+const maxImportBatchSize = 100
+
 type eventHubDriver struct {
-	config    internal.DriverConfig
-	logger    logger.Logger
-	batcher   *util.Batcher
-	producer  *azeventhubs.ProducerClient
-	waitGroup sync.WaitGroup
-	once      sync.Once
+	config       internal.DriverConfig
+	logger       logger.Logger
+	batcher      *util.Batcher
+	producer     *azeventhubs.ProducerClient
+	waitGroup    sync.WaitGroup
+	once         sync.Once
+	importConfig internal.ImporterConfig
+	dryRun       bool
 }
 
 var _ internal.Driver = (*eventHubDriver)(nil)
 var _ internal.DriverLifecycle = (*eventHubDriver)(nil)
 var _ internal.DriverHelp = (*eventHubDriver)(nil)
+var _ importer.Handler = (*eventHubDriver)(nil)
+var _ internal.Importer = (*eventHubDriver)(nil)
 
-// Start the driver. This is called once at the beginning of the driver's lifecycle.
-func (p *eventHubDriver) Start(pc internal.DriverConfig) error {
-	p.config = pc
-	p.batcher = util.NewBatcher()
-	p.logger = pc.Logger.WithPrefix("[eventhub]")
-
-	u, err := url.Parse(pc.URL)
+func (p *eventHubDriver) connect(urlString string) error {
+	u, err := url.Parse(urlString)
 	if err != nil {
 		return fmt.Errorf("unable to parse url: %w", err)
 	}
@@ -45,6 +47,18 @@ func (p *eventHubDriver) Start(pc internal.DriverConfig) error {
 		return fmt.Errorf("error connecting to eventhub: %w", err)
 	}
 	p.producer = producerClient
+	return nil
+}
+
+// Start the driver. This is called once at the beginning of the driver's lifecycle.
+func (p *eventHubDriver) Start(pc internal.DriverConfig) error {
+	p.config = pc
+	p.batcher = util.NewBatcher()
+	p.logger = pc.Logger.WithPrefix("[eventhub]")
+
+	if err := p.connect(pc.URL); err != nil {
+		return nil
+	}
 
 	p.logger.Info("started")
 	return nil
@@ -91,16 +105,36 @@ func (p *eventHubDriver) Process(event internal.DBChangeEvent) (bool, error) {
 	return false, nil
 }
 
+func (p *eventHubDriver) getKeys(record *util.Record, companyId string, locationId string) (string, string) {
+	key := fmt.Sprintf("dbchange.%s.%s.%s.%s.%s", record.Table, record.Operation, strWithDef(&companyId, "NONE"), strWithDef(&locationId, "NONE"), record.Id)
+	partitionKey := fmt.Sprintf("%s.%s.%s.%s", record.Table, strWithDef(&companyId, "NONE"), strWithDef(&locationId, "NONE"), record.Id)
+	return key, partitionKey
+}
+
+func (p *eventHubDriver) addEventToBatch(batch *azeventhubs.EventDataBatch, record *util.Record, key string) error {
+	if err := batch.AddEventData(&azeventhubs.EventData{
+		Body:        []byte(util.JSONStringify(record.Event)),
+		MessageID:   &record.Event.ID,
+		ContentType: &contentType,
+		Properties:  map[string]any{"objectId": key},
+	}, nil); err != nil {
+		return fmt.Errorf("error adding event to batch: %w", err)
+	}
+	return nil
+}
+
 // Flush is called to commit any pending events. It should return an error if the flush fails. If the flush fails, the driver will NAK all pending events.
 func (p *eventHubDriver) Flush() error {
+	p.logger.Debug("flush")
 	p.waitGroup.Add(1)
 	defer p.waitGroup.Done()
 	records := p.batcher.Records()
-	count := len(records)
+	count := p.batcher.Len()
 	if count > 0 {
 		p.batcher.Clear()
 		var batches []*azeventhubs.EventDataBatch
 		var pendingPartitionKey string
+		var offset int
 		for _, record := range records {
 			var companyId string
 			var locationId string
@@ -110,8 +144,7 @@ func (p *eventHubDriver) Flush() error {
 			if val, ok := record.Object["locationId"].(string); ok {
 				locationId = val
 			}
-			key := fmt.Sprintf("dbchange.%s.%s.%s.%s.%s", record.Table, record.Operation, strWithDef(&companyId, "NONE"), strWithDef(&locationId, "NONE"), record.Id)
-			partitionKey := fmt.Sprintf("%s.%s.%s", record.Table, strWithDef(&companyId, "NONE"), strWithDef(&locationId, "NONE"))
+			key, partitionKey := p.getKeys(record, companyId, locationId)
 			var batch *azeventhubs.EventDataBatch
 			if pendingPartitionKey == partitionKey {
 				batch = batches[len(batches)-1]
@@ -127,20 +160,20 @@ func (p *eventHubDriver) Flush() error {
 				pendingPartitionKey = partitionKey
 				batches = append(batches, b)
 			}
-			if err := batch.AddEventData(&azeventhubs.EventData{
-				Body:        []byte(util.JSONStringify(record.Event)),
-				MessageID:   &record.Event.ID,
-				ContentType: &contentType,
-				Properties:  map[string]any{"objectId": key},
-			}, nil); err != nil {
-				return fmt.Errorf("error adding event to batch: %w", err)
+			if err := p.addEventToBatch(batch, record, key); err != nil {
+				return err
 			}
-			for _, batch := range batches {
-				p.logger.Trace("sending batch with count: %d, bytes: %d", batch.NumEvents(), batch.NumBytes())
+		}
+		for _, batch := range batches {
+			if p.dryRun {
+				p.logger.Trace("would send batch (%03d/%03d) with count: %d, bytes: %d", 1+offset, count, batch.NumEvents(), batch.NumBytes())
+			} else {
+				p.logger.Trace("sending batch (%03d/%03d) with count: %d, bytes: %d", 1+offset, count, batch.NumEvents(), batch.NumBytes())
 				if err := p.producer.SendEventDataBatch(p.config.Context, batch, nil); err != nil {
 					return fmt.Errorf("error sending batch: %w", err)
 				}
 			}
+			offset += int(batch.NumEvents())
 		}
 	}
 	return nil
@@ -164,12 +197,53 @@ func (p *eventHubDriver) ExampleURL() string {
 // Help should return a detailed help documentation for the driver.
 func (p *eventHubDriver) Help() string {
 	var help strings.Builder
-	help.WriteString(util.GenerateHelpSection("Partitioning", "The partition key is calculated automatically based on the number of partitions for the topic and the incoming message.\nThe partition key is in the format: [TABLE].[COMPANY_ID].[LOCATION_ID].\n"))
+	help.WriteString(util.GenerateHelpSection("Partitioning", "The partition key is calculated automatically based on the number of partitions for the topic and the incoming message.\nThe partition key is in the format: [TABLE].[COMPANY_ID].[LOCATION_ID].[PRIMARY_KEY].\n"))
 	help.WriteString("\n")
 	help.WriteString(util.GenerateHelpSection("Message Value", "The message value is a JSON encoded value of the EDS DBChange event."))
 	return help.String()
 }
 
+// CreateDatasource allows the handler to create the datasource before importing data.
+func (p *eventHubDriver) CreateDatasource(schema internal.SchemaMap) error {
+	return nil
+}
+
+// ImportEvent allows the handler to process the event.
+func (p *eventHubDriver) ImportEvent(event internal.DBChangeEvent, schema *internal.Schema) error {
+	object, err := event.GetObject()
+	if err != nil {
+		return fmt.Errorf("error getting json object: %w", err)
+	}
+	p.batcher.Add(event.Table, event.GetPrimaryKey(), event.Operation, event.Diff, object, &event)
+
+	if p.batcher.Len() >= maxImportBatchSize {
+		return p.Flush()
+	}
+	return nil
+}
+
+// ImportCompleted is called when all events have been processed.
+func (p *eventHubDriver) ImportCompleted() error {
+	if p.batcher != nil {
+		return p.Flush()
+	}
+	p.producer.Close(context.Background())
+	return nil
+}
+
+func (p *eventHubDriver) Import(config internal.ImporterConfig) error {
+	p.logger = config.Logger.WithPrefix("[eventhub]")
+	if err := p.connect(config.URL); err != nil {
+		return err
+	}
+	p.config.Context = config.Context
+	p.dryRun = config.DryRun
+	p.importConfig = config
+	p.batcher = util.NewBatcher()
+	return importer.Run(p.logger, config, p)
+}
+
 func init() {
 	internal.RegisterDriver("eventhub", &eventHubDriver{})
+	internal.RegisterImporter("eventhub", &eventHubDriver{})
 }

--- a/internal/drivers/file/file.go
+++ b/internal/drivers/file/file.go
@@ -25,6 +25,7 @@ var _ internal.Driver = (*fileDriver)(nil)
 var _ internal.DriverLifecycle = (*fileDriver)(nil)
 var _ internal.DriverHelp = (*fileDriver)(nil)
 var _ internal.Importer = (*fileDriver)(nil)
+var _ internal.ImporterHelp = (*fileDriver)(nil)
 var _ importer.Handler = (*fileDriver)(nil)
 
 func (p *fileDriver) GetPathFromURL(urlString string) (string, error) {

--- a/internal/drivers/file/file.go
+++ b/internal/drivers/file/file.go
@@ -158,6 +158,11 @@ func (p *fileDriver) Import(config internal.ImporterConfig) error {
 	return importer.Run(p.logger, config, p)
 }
 
+// SupportsDelete returns true if the importer supports deleting data.
+func (p *fileDriver) SupportsDelete() bool {
+	return false
+}
+
 func init() {
 	internal.RegisterDriver("file", &fileDriver{})
 	internal.RegisterImporter("file", &fileDriver{})

--- a/internal/drivers/file/file.go
+++ b/internal/drivers/file/file.go
@@ -9,20 +9,23 @@ import (
 	"time"
 
 	"github.com/shopmonkeyus/eds-server/internal"
+	"github.com/shopmonkeyus/eds-server/internal/importer"
 	"github.com/shopmonkeyus/eds-server/internal/util"
 	"github.com/shopmonkeyus/go-common/logger"
 )
 
 type fileDriver struct {
-	config internal.DriverConfig
-	logger logger.Logger
-	dir    string
+	config       internal.DriverConfig
+	logger       logger.Logger
+	dir          string
+	importConfig internal.ImporterConfig
 }
 
 var _ internal.Driver = (*fileDriver)(nil)
 var _ internal.DriverLifecycle = (*fileDriver)(nil)
 var _ internal.DriverHelp = (*fileDriver)(nil)
 var _ internal.Importer = (*fileDriver)(nil)
+var _ importer.Handler = (*fileDriver)(nil)
 
 func (p *fileDriver) GetPathFromURL(urlString string) (string, error) {
 	u, err := url.Parse(urlString)
@@ -131,61 +134,28 @@ func (p *fileDriver) Help() string {
 	return help.String()
 }
 
+// CreateDatasource allows the handler to create the datasource before importing data.
+func (p *fileDriver) CreateDatasource(schema internal.SchemaMap) error {
+	return nil
+}
+
+// ImportEvent allows the handler to process the event.
+func (p *fileDriver) ImportEvent(event internal.DBChangeEvent, schema *internal.Schema) error {
+	return p.writeEvent(p.logger, event, p.importConfig.DryRun)
+}
+
+// ImportCompleted is called when all events have been processed.
+func (p *fileDriver) ImportCompleted() error {
+	return nil
+}
+
 func (p *fileDriver) Import(config internal.ImporterConfig) error {
-	logger := config.Logger.WithPrefix("[file]")
+	p.logger = config.Logger.WithPrefix("[file]")
 	if _, err := p.GetPathFromURL(config.URL); err != nil {
 		return err
 	}
-	files, err := util.ListDir(config.DataDir)
-	if err != nil {
-		return fmt.Errorf("unable to list files in directory: %w", err)
-	}
-	schema, err := config.SchemaRegistry.GetLatestSchema()
-	if err != nil {
-		return fmt.Errorf("unable to get schema: %w", err)
-	}
-	started := time.Now()
-	var total int
-	for _, file := range files {
-		table, _, ok := util.ParseCRDBExportFile(file)
-		if !ok {
-			logger.Debug("skipping file: %s", file)
-			continue
-		}
-		if !util.SliceContains(config.Tables, table) {
-			continue
-		}
-		data := schema[table]
-		if data == nil {
-			return fmt.Errorf("unexpected table (%s) not found in schema but in import directory: %s", table, file)
-		}
-		logger.Debug("processing file: %s, table: %s", file, table)
-		dec, err := util.NewNDJSONDecoder(file)
-		if err != nil {
-			return fmt.Errorf("unable to create JSON decoder for %s: %w", file, err)
-		}
-		defer dec.Close()
-		var count int
-		tstarted := time.Now()
-		for dec.More() {
-			var event internal.DBChangeEvent
-			if err := dec.Decode(&event); err != nil {
-				return fmt.Errorf("unable to decode JSON: %w", err)
-			}
-			count++
-			if err := p.writeEvent(logger, event, config.DryRun); err != nil {
-				return err
-			}
-		}
-		if err := dec.Close(); err != nil {
-			return err
-		}
-		total += count
-		logger.Debug("imported %d %s records in %s", count, table, time.Since(tstarted))
-	}
-
-	logger.Info("imported %d records from %d files in %s", total, len(files), time.Since(started))
-	return nil
+	p.importConfig = config
+	return importer.Run(p.logger, config, p)
 }
 
 func init() {

--- a/internal/drivers/kafka/kafka.go
+++ b/internal/drivers/kafka/kafka.go
@@ -49,6 +49,7 @@ var _ internal.Driver = (*kafkaDriver)(nil)
 var _ internal.DriverLifecycle = (*kafkaDriver)(nil)
 var _ internal.DriverHelp = (*kafkaDriver)(nil)
 var _ internal.Importer = (*kafkaDriver)(nil)
+var _ internal.ImporterHelp = (*kafkaDriver)(nil)
 var _ importer.Handler = (*kafkaDriver)(nil)
 
 func (p *kafkaDriver) connect(urlString string) error {

--- a/internal/drivers/kafka/kafka.go
+++ b/internal/drivers/kafka/kafka.go
@@ -110,7 +110,7 @@ func (p *kafkaDriver) MaxBatchSize() int {
 }
 
 func strWithDef(val *string, def string) string {
-	if val == nil {
+	if val == nil || *val == "" {
 		return def
 	}
 	return *val
@@ -213,6 +213,11 @@ func (p *kafkaDriver) Import(config internal.ImporterConfig) error {
 		return err
 	}
 	return importer.Run(p.logger, config, p)
+}
+
+// SupportsDelete returns true if the importer supports deleting data.
+func (p *kafkaDriver) SupportsDelete() bool {
+	return false
 }
 
 func init() {

--- a/internal/drivers/s3/s3.go
+++ b/internal/drivers/s3/s3.go
@@ -61,6 +61,7 @@ var _ internal.Driver = (*s3Driver)(nil)
 var _ internal.DriverLifecycle = (*s3Driver)(nil)
 var _ internal.DriverHelp = (*s3Driver)(nil)
 var _ internal.Importer = (*s3Driver)(nil)
+var _ internal.ImporterHelp = (*s3Driver)(nil)
 var _ importer.Handler = (*s3Driver)(nil)
 
 // Start the driver. This is called once at the beginning of the driver's lifecycle.

--- a/internal/drivers/s3/s3.go
+++ b/internal/drivers/s3/s3.go
@@ -243,6 +243,11 @@ func (p *s3Driver) Import(config internal.ImporterConfig) error {
 	return importer.Run(p.logger, config, p)
 }
 
+// SupportsDelete returns true if the importer supports deleting data.
+func (p *s3Driver) SupportsDelete() bool {
+	return false
+}
+
 func init() {
 	internal.RegisterDriver("s3", &s3Driver{})
 	internal.RegisterImporter("s3", &s3Driver{})

--- a/internal/importer.go
+++ b/internal/importer.go
@@ -50,6 +50,12 @@ type Importer interface {
 	Import(config ImporterConfig) error
 }
 
+// ImporterHelp is the interface that is optionally implemented by importers to provide additional help.
+type ImporterHelp interface {
+	// SupportsDelete returns true if the importer supports deleting data.
+	SupportsDelete() bool
+}
+
 var importerRegistry = map[string]Importer{}
 var importerAliasRegistry = map[string]string{}
 

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -70,6 +70,7 @@ func Run(logger logger.Logger, config internal.ImporterConfig, handler Handler) 
 				return fmt.Errorf("unable to decode JSON: %w", err)
 			}
 			event.Key = []string{event.GetPrimaryKey()}
+			event.Imported = true
 			count++
 			if err := handler.ImportEvent(event, data); err != nil {
 				return err

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -1,0 +1,86 @@
+package importer
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/shopmonkeyus/eds-server/internal"
+	"github.com/shopmonkeyus/eds-server/internal/util"
+	"github.com/shopmonkeyus/go-common/logger"
+)
+
+// Handler is the interface importers use to handle processing the event.
+type Handler interface {
+	// CreateDatasource allows the handler to create the datasource before importing data.
+	CreateDatasource(schema internal.SchemaMap) error
+
+	// ImportEvent allows the handler to process the event.
+	ImportEvent(event internal.DBChangeEvent, schema *internal.Schema) error
+
+	// ImportCompleted is called when all events have been processed.
+	ImportCompleted() error
+}
+
+// Run will import data from the importer configuration and call the handler to handle the event.
+func Run(logger logger.Logger, config internal.ImporterConfig, handler Handler) error {
+	files, err := util.ListDir(config.DataDir)
+	if err != nil {
+		return fmt.Errorf("unable to list files in directory: %w", err)
+	}
+	schema, err := config.SchemaRegistry.GetLatestSchema()
+	if err != nil {
+		return fmt.Errorf("unable to get schema: %w", err)
+	}
+	started := time.Now()
+	if err := handler.CreateDatasource(schema); err != nil {
+		return err
+	}
+	var total int
+	for _, file := range files {
+		table, tv, ok := util.ParseCRDBExportFile(file)
+		if !ok {
+			logger.Debug("skipping file: %s", file)
+			continue
+		}
+		if !util.SliceContains(config.Tables, table) {
+			continue
+		}
+		data := schema[table]
+		if data == nil {
+			return fmt.Errorf("unexpected table (%s) not found in schema but in import directory: %s", table, file)
+		}
+		logger.Debug("processing file: %s, table: %s", file, table)
+		dec, err := util.NewNDJSONDecoder(file)
+		if err != nil {
+			return fmt.Errorf("unable to create JSON decoder for %s: %w", file, err)
+		}
+		defer dec.Close()
+		var count int
+		tstarted := time.Now()
+		for dec.More() {
+			var event internal.DBChangeEvent
+			event.Operation = "INSERT"
+			event.Table = table
+			event.Timestamp = tv.UnixMilli()
+			if err := dec.Decode(&event.After); err != nil {
+				return fmt.Errorf("unable to decode JSON: %w", err)
+			}
+			count++
+			if err := handler.ImportEvent(event, data); err != nil {
+				return err
+			}
+		}
+		if err := dec.Close(); err != nil {
+			return err
+		}
+		total += count
+		logger.Debug("imported %d %s records in %s", count, table, time.Since(tstarted))
+	}
+
+	if err := handler.ImportCompleted(); err != nil {
+		return err
+	}
+
+	logger.Info("imported %d records from %d files in %s", total, len(files), time.Since(started))
+	return nil
+}

--- a/internal/util/api.go
+++ b/internal/util/api.go
@@ -1,0 +1,18 @@
+package util
+
+import (
+	"fmt"
+
+	jwt "github.com/golang-jwt/jwt/v5"
+)
+
+// GetAPIURLFromJWT extracts the API URL from a JWT token
+func GetAPIURLFromJWT(jwtString string) (string, error) {
+	p := jwt.NewParser(jwt.WithoutClaimsValidation())
+	var claims jwt.RegisteredClaims
+	tokens, _, err := p.ParseUnverified(jwtString, &claims)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse jwt: %w", err)
+	}
+	return tokens.Claims.GetIssuer()
+}

--- a/internal/util/api_test.go
+++ b/internal/util/api_test.go
@@ -1,0 +1,13 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetAPIURLFromJWT(t *testing.T) {
+	url, err := GetAPIURLFromJWT("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJhcGkiLCJjaWQiOiI2Mjg3YTQxNTRkMWE3MmNjNWNlMDkxYmIiLCJpZCI6IjYyODdhNDA0NGQxYTcyM2IxMGUwOTFiOSIsImxpZCI6IjYyODdhNDA0NGQxYTcyM2IxMGVmZjFiMCIsIm9uIjo2LCJyaWQiOiJ1dzEiLCJzYWQiOjAsInNpZCI6IjM2MjczMzYwZWZkMDA1ZjgiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjMxMDEiLCJpYXQiOjE3MjI0ODY4MzJ9.5fPgQJFBuZWBCaXsPN7uKXKsamfkxP5ssEBI3EECEv0")
+	assert.NoError(t, err)
+	assert.Equal(t, "http://localhost:3101", url)
+}

--- a/internal/util/batcher.go
+++ b/internal/util/batcher.go
@@ -22,12 +22,12 @@ func (r *Record) String() string {
 	return JSONStringify(r)
 }
 
-// Records returns the array of records
+// Records returns the array of records.
 func (b *Batcher) Records() []*Record {
 	return b.records
 }
 
-// Add will add a record to the batcher
+// Add will add a record to the batcher.
 func (b *Batcher) Add(table string, id string, operation string, diff []string, payload map[string]any, event *internal.DBChangeEvent) {
 	var primaryKey string
 	if val, ok := payload["id"].(string); ok {
@@ -68,18 +68,18 @@ func (b *Batcher) Add(table string, id string, operation string, diff []string, 
 	}
 }
 
-// Clear will clear the batcher and reset the internal state
+// Clear will clear the batcher and reset the internal state.
 func (b *Batcher) Clear() {
 	b.records = nil
 	b.pks = make(map[string]uint)
 }
 
-// Clear will clear the batcher and reset the internal state
+// Len will return the number of records pending in the batcher.
 func (b *Batcher) Len() int {
 	return len(b.records)
 }
 
-// NewBatcher creates a new batcher instance
+// NewBatcher creates a new batcher instance.
 func NewBatcher() *Batcher {
 	return &Batcher{
 		pks: make(map[string]uint),

--- a/internal/util/batcher.go
+++ b/internal/util/batcher.go
@@ -1,6 +1,8 @@
 package util
 
-import "github.com/shopmonkeyus/eds-server/internal"
+import (
+	"github.com/shopmonkeyus/eds-server/internal"
+)
 
 type Batcher struct {
 	records []*Record
@@ -70,6 +72,11 @@ func (b *Batcher) Add(table string, id string, operation string, diff []string, 
 func (b *Batcher) Clear() {
 	b.records = nil
 	b.pks = make(map[string]uint)
+}
+
+// Clear will clear the batcher and reset the internal state
+func (b *Batcher) Len() int {
+	return len(b.records)
 }
 
 // NewBatcher creates a new batcher instance

--- a/internal/util/errors.go
+++ b/internal/util/errors.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"fmt"
 	"os"
 	"runtime/pprof"
 	"strings"
@@ -18,6 +19,7 @@ var depth = 3
 
 func RecoverPanic(logger logger.Logger) {
 	if r := recover(); r != nil {
+		fmt.Println("PANIC", r)
 		v := panicError(depth, r)
 		var str strings.Builder
 		pprof.Lookup("goroutine").WriteTo(&str, 2)

--- a/internal/util/errors.go
+++ b/internal/util/errors.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	"fmt"
 	"os"
 	"runtime/pprof"
 	"strings"
@@ -19,7 +18,6 @@ var depth = 3
 
 func RecoverPanic(logger logger.Logger) {
 	if r := recover(); r != nil {
-		fmt.Println("PANIC", r)
 		v := panicError(depth, r)
 		var str strings.Builder
 		pprof.Lookup("goroutine").WriteTo(&str, 2)

--- a/internal/util/http.go
+++ b/internal/util/http.go
@@ -38,7 +38,7 @@ func (r *HTTPRetry) Do() (*http.Response, error) {
 	r.attempts++
 	resp, err := http.DefaultClient.Do(r.req)
 	if r.shouldRetry(resp, err) {
-		jitter := time.Duration(rand.Int63n(int64(r.attempts * 250)))
+		jitter := time.Duration(time.Millisecond*100 + time.Millisecond*time.Duration(rand.Int63n(int64(500*r.attempts))))
 		time.Sleep(jitter)
 		return r.Do()
 	}


### PR DESCRIPTION
Refactor import to maximize reuse across multiple drivers.

Added import support for Kafka, EventHub and AWS.

Fixed batching issue with EventHub adding duplicates into batches.

Use the API Key to set the default API URL.

Fixed enroll API path for non localhost.

Add `imported` flag on DBChange during import so upstream drivers can use this to know when the event is from an import or replay