### PR TITLE
[VCARB-78] add support for schema validation for server/import using JSON schema

### DIFF
--- a/cmd/fork.go
+++ b/cmd/fork.go
@@ -122,7 +122,7 @@ var forkCmd = &cobra.Command{
 			}
 		}
 
-		driver, err := internal.NewDriver(ctx, logger, url, schemaRegistry, tracker)
+		driver, err := internal.NewDriver(ctx, logger, url, schemaRegistry, tracker, datadir)
 		if err != nil {
 			logger.Error("error creating driver: %s", err)
 			os.Exit(3)

--- a/cmd/fork.go
+++ b/cmd/fork.go
@@ -73,6 +73,12 @@ var forkCmd = &cobra.Command{
 
 		schemaFile, tablesFile := getSchemaAndTableFiles(datadir)
 
+		// check to see if there's a schema validator and if so load it
+		validator, err := loadSchemaValidator(cmd)
+		if err != nil {
+			logger.Fatal("error loading validator: %s", err)
+		}
+
 		tracker, err := tracker.NewTracker(tracker.TrackerConfig{
 			Logger:  logger,
 			Context: ctx,
@@ -194,6 +200,7 @@ var forkCmd = &cobra.Command{
 						Driver:                driver,
 						ExportTableTimestamps: exportTableTimestamps,
 						DeliverAll:            restartFlag,
+						SchemaValidator:       validator,
 					})
 					if err != nil {
 						logger.Error("error creating consumer: %s", err)

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -480,6 +480,7 @@ var importCmd = &cobra.Command{
 
 		var success bool
 		defer func() {
+			defer util.RecoverPanic(logger)
 			logger.Trace("exit success: %v", success)
 			var filesRemoved bool
 			if success {
@@ -500,6 +501,7 @@ var importCmd = &cobra.Command{
 				os.Exit(1)
 			}
 		}()
+		defer util.RecoverPanic(logger) // panic recover needs to happen after the defer above
 
 		if dir == "" {
 			if jobID == "" {

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -409,6 +409,12 @@ var importCmd = &cobra.Command{
 
 		var err error
 
+		// check to see if there's a schema validator and if so load it
+		validator, err := loadSchemaValidator(cmd)
+		if err != nil {
+			logger.Fatal("error loading validator: %s", err)
+		}
+
 		// load the schema from the api fresh
 		registry, err := registry.NewAPIRegistry(apiURL)
 		if err != nil {
@@ -582,16 +588,17 @@ var importCmd = &cobra.Command{
 		}
 		logger.Info("Importing data to tables %s", strings.Join(tables, ", "))
 		if err := importer.Import(internal.ImporterConfig{
-			Context:        ctx,
-			URL:            driverUrl,
-			Logger:         logger,
-			SchemaRegistry: registry,
-			MaxParallel:    parallel,
-			JobID:          jobID,
-			DataDir:        dir,
-			DryRun:         dryRun,
-			Tables:         tables,
-			Single:         single,
+			Context:         ctx,
+			URL:             driverUrl,
+			Logger:          logger,
+			SchemaRegistry:  registry,
+			MaxParallel:     parallel,
+			JobID:           jobID,
+			DataDir:         dir,
+			DryRun:          dryRun,
+			Tables:          tables,
+			Single:          single,
+			SchemaValidator: validator,
 		}); err != nil {
 			logger.Error("error running import: %s", err)
 			return

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/shopmonkeyus/eds-server/internal"
 	"github.com/shopmonkeyus/eds-server/internal/util"
 	"github.com/shopmonkeyus/go-common/logger"
 	"github.com/spf13/cobra"
@@ -200,6 +201,14 @@ func getSchemaAndTableFiles(datadir string) (string, string) {
 	return schemaFile, tablesFile
 }
 
+func loadSchemaValidator(cmd *cobra.Command) (internal.SchemaValidator, error) {
+	schemaDir := mustFlagString(cmd, "schema-validator", false)
+	if schemaDir == "" {
+		return nil, nil
+	}
+	return util.NewSchemaValidator(schemaDir)
+}
+
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:  "eds-server",
@@ -221,4 +230,5 @@ func init() {
 	rootCmd.PersistentFlags().Bool("timestamp", false, "turn on timestamps in logs")
 	rootCmd.PersistentFlags().String("log-file-sink", "", "the log file sink to use")
 	rootCmd.PersistentFlags().MarkHidden("log-file-sink")
+	rootCmd.PersistentFlags().String("schema-validator", "", "the schema validator directory to use")
 }

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/nats-io/nats.go v1.36.0
 	github.com/prometheus/client_golang v1.19.1
 	github.com/prometheus/client_model v0.6.1
+	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/savsgio/gotils v0.0.0-20240704082632-aef3928b8a38
 	github.com/segmentio/kafka-go v0.4.47
 	github.com/shirou/gopsutil/v4 v4.24.7

--- a/go.sum
+++ b/go.sum
@@ -239,6 +239,8 @@ github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/f
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
 github.com/savsgio/gotils v0.0.0-20240704082632-aef3928b8a38 h1:D0vL7YNisV2yqE55+q0lFuGse6U8lxlg7fYTctlT5Gc=
 github.com/savsgio/gotils v0.0.0-20240704082632-aef3928b8a38/go.mod h1:sM7Mt7uEoCeFSCBM+qBrqvEo+/9vdmj19wzp3yzUhmg=
 github.com/segmentio/kafka-go v0.4.47 h1:IqziR4pA3vrZq7YdRxaT3w1/5fvIH5qpCwstUanQQB0=

--- a/internal/consumer/consumer.go
+++ b/internal/consumer/consumer.go
@@ -58,6 +58,9 @@ type ConsumerConfig struct {
 
 	// DeliverAll will configure the consumer to read from the beginning of the stream, this only works if the consumer is new
 	DeliverAll bool
+
+	// SchemaValidator is the schema validator to use for the importer or nil if not needed.
+	SchemaValidator internal.SchemaValidator
 }
 
 type Consumer struct {
@@ -81,6 +84,7 @@ type Consumer struct {
 	subError        chan error
 	sessionID       string
 	tableTimestamps map[string]*time.Time
+	validator       internal.SchemaValidator
 }
 
 // Stop the consumer and close the connection to the NATS server.
@@ -174,7 +178,7 @@ func (c *Consumer) flush() bool {
 	return c.stopping
 }
 
-func (c *Consumer) shouldSkip(evt *internal.DBChangeEvent) bool {
+func (c *Consumer) shouldSkip(logger logger.Logger, evt *internal.DBChangeEvent) bool {
 	if c.tableTimestamps == nil {
 		return false
 	}
@@ -182,6 +186,25 @@ func (c *Consumer) shouldSkip(evt *internal.DBChangeEvent) bool {
 	// check if we have a timestamp for this table and only process if its newer
 	if tableTimestamp := c.tableTimestamps[evt.Table]; tableTimestamp != nil {
 		return eventTimestamp.Before(*tableTimestamp)
+	}
+	if c.validator != nil {
+		found, valid, path, err := c.validator.Validate(*evt)
+		if err != nil {
+			logger.Error("error validating schema: %s", err)
+			return true
+		}
+		if !found {
+			logger.Trace("skipping %s, no schema found for event: %s", evt.Table, util.JSONStringify(evt))
+			return true
+		}
+		if !valid {
+			logger.Trace("skipping %s, schema did not validate for event: %s", evt.Table, util.JSONStringify(evt))
+			return true
+		}
+		if path != "" {
+			evt.SchemaValidatedPath = &path
+			logger.Trace("schema validated %s", path)
+		}
 	}
 	return false
 }
@@ -225,7 +248,7 @@ func (c *Consumer) bufferer() {
 				c.handleError(err)
 				return
 			}
-			if c.shouldSkip(&evt) {
+			if c.shouldSkip(log, &evt) {
 				log.Trace("skipping event due to timestamp %d", evt.Timestamp)
 				if err := msg.Ack(); err != nil {
 					// not much we can do here, just log it
@@ -484,6 +507,7 @@ func CreateConsumer(config ConsumerConfig) (*Consumer, error) {
 	consumer.pending = make([]jetstream.Msg, 0)
 	consumer.subError = make(chan error, 10)
 	consumer.sessionID = info.sessionID
+	consumer.validator = config.SchemaValidator
 	consumer.logger = config.Logger.WithPrefix("[consumer]")
 	if config.ExportTableTimestamps != nil {
 		consumer.tableTimestamps = config.ExportTableTimestamps

--- a/internal/dbchange.go
+++ b/internal/dbchange.go
@@ -15,6 +15,7 @@ type DBChangeEvent struct {
 	ModelVersion  string          `json:"modelVersion"`
 	CompanyID     *string         `json:"companyId,omitempty"`
 	LocationID    *string         `json:"locationId,omitempty"`
+	UserID        *string         `json:"userId,omitempty"`
 	Before        json.RawMessage `json:"before,omitempty"`
 	After         json.RawMessage `json:"after,omitempty"`
 	Diff          []string        `json:"diff,omitempty"`

--- a/internal/dbchange.go
+++ b/internal/dbchange.go
@@ -26,6 +26,8 @@ type DBChangeEvent struct {
 	NatsMsg  jetstream.Msg `json:"-"`        // could be nil
 
 	object map[string]any
+
+	SchemaValidatedPath *string `json:"-"` // set by the schema validator if valid and the path is returned as non-empty and not nil
 }
 
 func (c *DBChangeEvent) String() string {

--- a/internal/driver.go
+++ b/internal/driver.go
@@ -29,6 +29,9 @@ type DriverConfig struct {
 
 	// Tracker is the local (on disk) database for tracking stuff that the driver can use.
 	Tracker *tracker.Tracker
+
+	// DataDir is the directory where the driver can store data.
+	DataDir string
 }
 
 // DriverSessionHandler is for drivers that want to receive the session id
@@ -153,7 +156,7 @@ func RegisterDriver(protocol string, driver Driver) {
 }
 
 // NewDriver creates a new driver for the given URL.
-func NewDriver(ctx context.Context, logger logger.Logger, urlString string, registry SchemaRegistry, tracker *tracker.Tracker) (Driver, error) {
+func NewDriver(ctx context.Context, logger logger.Logger, urlString string, registry SchemaRegistry, tracker *tracker.Tracker, datadir string) (Driver, error) {
 	u, err := url.Parse(urlString)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse URL: %w", err)
@@ -177,6 +180,7 @@ func NewDriver(ctx context.Context, logger logger.Logger, urlString string, regi
 			Logger:         logger.WithPrefix(fmt.Sprintf("[%s]", u.Scheme)),
 			SchemaRegistry: registry,
 			Tracker:        tracker,
+			DataDir:        datadir,
 		}); err != nil {
 			return nil, err
 		}

--- a/internal/drivers/s3/s3.go
+++ b/internal/drivers/s3/s3.go
@@ -8,7 +8,9 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -51,6 +53,12 @@ func (lt *RecalculateV4Signature) RoundTrip(req *http.Request) (*http.Response, 
 	return lt.next.RoundTrip(req)
 }
 
+type job struct {
+	logger logger.Logger
+	event  internal.DBChangeEvent
+	key    string
+}
+
 type s3Driver struct {
 	config       internal.DriverConfig
 	logger       logger.Logger
@@ -58,6 +66,10 @@ type s3Driver struct {
 	prefix       string
 	s3           *awss3.Client
 	importConfig internal.ImporterConfig
+	waitGroup    sync.WaitGroup
+	jobWaitGroup sync.WaitGroup
+	ch           chan job
+	errors       chan error
 }
 
 var _ internal.Driver = (*s3Driver)(nil)
@@ -155,17 +167,70 @@ func (p *s3Driver) connect(ctx context.Context, logger logger.Logger, urlString 
 
 	if _, err := p.s3.ListObjects(ctx, &awss3.ListObjectsInput{Bucket: aws.String(p.bucket), MaxKeys: aws.Int32(1)}); err != nil {
 		var bnf *types.NoSuchBucket
-		if errors.As(err, &bnf) {
-			if _, err := p.s3.CreateBucket(ctx, &awss3.CreateBucketInput{Bucket: aws.String(p.bucket)}); err != nil {
-				return fmt.Errorf("bucket not found and unable to create bucket %s: %w", p.bucket, err)
+		// only attempt to create the bucket if we are using localhost
+		if strings.Contains(host, "localhost") {
+			if errors.As(err, &bnf) {
+				if _, err := p.s3.CreateBucket(ctx, &awss3.CreateBucketInput{Bucket: aws.String(p.bucket)}); err != nil {
+					return fmt.Errorf("bucket not found and unable to create bucket %s: %w", p.bucket, err)
+				}
+				logger.Info("created bucket %s", p.bucket)
+				return nil // we created the bucket ok
 			}
-			logger.Info("created bucket %s", p.bucket)
-			return nil // we created the bucket ok
 		}
 		return fmt.Errorf("unable to verify bucket %s: %w", p.bucket, bnf)
 	}
 
+	maxBatchSize := 1_000 // maximum number of events to batch
+	uploadTasks := 4      // number of concurrent upload tasks
+
+	if u.Query().Get("maxBatchSize") != "" {
+		maxBatchSize, err = strconv.Atoi(u.Query().Get("maxBatchSize"))
+		if err != nil {
+			return fmt.Errorf("unable to parse maxBatchSize: %w", err)
+		}
+		if maxBatchSize <= 0 {
+			maxBatchSize = 1_000
+		}
+	}
+	if u.Query().Get("uploadTasks") != "" {
+		uploadTasks, err = strconv.Atoi(u.Query().Get("uploadTasks"))
+		if err != nil {
+			return fmt.Errorf("unable to parse uploadTasks: %w", err)
+		}
+		if uploadTasks <= 0 {
+			uploadTasks = 4
+		}
+	}
+	p.logger.Debug("setting maxBatchSize=%d uploadTasks=%d", maxBatchSize, uploadTasks)
+
+	p.ch = make(chan job, maxBatchSize)
+	p.errors = make(chan error, maxBatchSize)
+	for i := 0; i < uploadTasks; i++ {
+		p.waitGroup.Add(1)
+		go p.run()
+	}
+
 	return nil
+}
+
+func (p *s3Driver) run() {
+	defer p.waitGroup.Done()
+	for job := range p.ch {
+		buf := []byte(util.JSONStringify(job.event))
+		_, err := p.s3.PutObject(context.Background(), &awss3.PutObjectInput{
+			Bucket:        aws.String(p.bucket),
+			Key:           aws.String(job.key),
+			ContentType:   aws.String("application/json"),
+			Body:          bytes.NewReader(buf),
+			ContentLength: aws.Int64(int64(len(buf))),
+		})
+		if err != nil {
+			p.errors <- fmt.Errorf("error storing s3 object to %s:%s: %w", p.bucket, job.key, err)
+		} else {
+			job.logger.Trace("uploaded to %s:%s", p.bucket, job.key)
+		}
+		p.jobWaitGroup.Done()
+	}
 }
 
 // Start the driver. This is called once at the beginning of the driver's lifecycle.
@@ -180,16 +245,21 @@ func (p *s3Driver) Start(pc internal.DriverConfig) error {
 
 // Stop the driver. This is called once at the end of the driver's lifecycle.
 func (p *s3Driver) Stop() error {
+	p.logger.Debug("stopping s3 driver")
+	p.jobWaitGroup.Wait()
+	close(p.ch)
+	p.waitGroup.Wait()
+	p.logger.Debug("stopped s3 driver")
 	return nil
 }
 
 // MaxBatchSize returns the maximum number of events that can be processed in a single call to Process and when Flush should be called.
 // Return -1 to indicate that there is no limit.
 func (p *s3Driver) MaxBatchSize() int {
-	return 1
+	return 1_000
 }
 
-func (p *s3Driver) process(ctx context.Context, logger logger.Logger, event internal.DBChangeEvent, dryRun bool) (bool, error) {
+func (p *s3Driver) process(_ context.Context, logger logger.Logger, event internal.DBChangeEvent, dryRun bool) (bool, error) {
 	var key string
 	if event.SchemaValidatedPath != nil {
 		key = *event.SchemaValidatedPath
@@ -199,18 +269,8 @@ func (p *s3Driver) process(ctx context.Context, logger logger.Logger, event inte
 	if dryRun {
 		logger.Trace("would store %s:%s", p.bucket, key)
 	} else {
-		buf := []byte(util.JSONStringify(event))
-		_, err := p.s3.PutObject(ctx, &awss3.PutObjectInput{
-			Bucket:        aws.String(p.bucket),
-			Key:           aws.String(key),
-			ContentType:   aws.String("application/json"),
-			Body:          bytes.NewReader(buf),
-			ContentLength: aws.Int64(int64(len(buf))),
-		})
-		if err != nil {
-			return true, fmt.Errorf("error storing s3 object to %s:%s: %w", p.bucket, key, err)
-		}
-		logger.Trace("stored %s:%s", p.bucket, key)
+		p.jobWaitGroup.Add(1)
+		p.ch <- job{logger, event, key}
 	}
 	return false, nil
 }
@@ -222,7 +282,23 @@ func (p *s3Driver) Process(logger logger.Logger, event internal.DBChangeEvent) (
 
 // Flush is called to commit any pending events. It should return an error if the flush fails. If the flush fails, the driver will NAK all pending events.
 func (p *s3Driver) Flush() error {
-	return nil
+	p.logger.Debug("flush called")
+	p.jobWaitGroup.Wait()
+	var errs []error
+done:
+	for {
+		select {
+		case err := <-p.errors:
+			errs = append(errs, err)
+		default:
+			break done
+		}
+	}
+	p.logger.Debug("flush finished")
+	if len(errs) == 0 {
+		return nil
+	}
+	return errors.Join(errs...)
 }
 
 // Name is a unique name for the driver.

--- a/internal/importer.go
+++ b/internal/importer.go
@@ -24,6 +24,9 @@ type ImporterConfig struct {
 	// SchemaRegistry is the schema registry to use for the importer.
 	SchemaRegistry SchemaRegistry
 
+	// SchemaValidator is the schema validator to use for the importer or nil if not needed.
+	SchemaValidator SchemaValidator
+
 	// MaxParallel is the maximum number of tables to import in parallel (if supported by the Importer).
 	MaxParallel int
 

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -70,6 +70,19 @@ func Run(logger logger.Logger, config internal.ImporterConfig, handler Handler) 
 				return fmt.Errorf("unable to decode JSON: %w", err)
 			}
 			event.Key = []string{event.GetPrimaryKey()}
+			o, err := event.GetObject()
+			if err != nil {
+				return fmt.Errorf("unable to get object: %w", err)
+			}
+			if id, ok := o["locationId"].(string); ok {
+				event.LocationID = &id
+			}
+			if id, ok := o["companyId"].(string); ok {
+				event.LocationID = &id
+			}
+			if id, ok := o["userId"].(string); ok {
+				event.UserID = &id
+			}
 			event.Imported = true
 			count++
 			if err := handler.ImportEvent(event, data); err != nil {

--- a/internal/schema.go
+++ b/internal/schema.go
@@ -43,3 +43,9 @@ type SchemaRegistry interface {
 	// Save the latest schema to a file.
 	Save(filename string) error
 }
+
+// SchemaValidator is the interface for a schema validator.
+type SchemaValidator interface {
+	// Validate the event against the schema.
+	Validate(event DBChangeEvent) (bool, bool, string, error)
+}

--- a/internal/schema.go
+++ b/internal/schema.go
@@ -46,6 +46,6 @@ type SchemaRegistry interface {
 
 // SchemaValidator is the interface for a schema validator.
 type SchemaValidator interface {
-	// Validate the event against the schema.
+	// Validate the event against the schema. Returns true if a schema is found for the table, true if the event is valid, the path transformed and an error if one occurs.
 	Validate(event DBChangeEvent) (bool, bool, string, error)
 }

--- a/internal/util/batcher.go
+++ b/internal/util/batcher.go
@@ -1,8 +1,6 @@
 package util
 
-import (
-	"github.com/shopmonkeyus/eds-server/internal"
-)
+import "github.com/shopmonkeyus/eds-server/internal"
 
 type Batcher struct {
 	records []*Record

--- a/internal/util/schema.go
+++ b/internal/util/schema.go
@@ -1,0 +1,181 @@
+package util
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"os"
+	"path/filepath"
+	"strings"
+
+	js "github.com/santhosh-tekuri/jsonschema/v5"
+	"github.com/shopmonkeyus/eds-server/internal"
+)
+
+type SchemaValidator struct {
+	compiler *js.Compiler
+	rules    map[string]*SchemaValidationRule
+}
+
+type SchemaValidationRule struct {
+	Schema string `json:"schema"`
+	Path   string `json:"path"`
+
+	// internal
+	schema   *js.Schema
+	template *template.Template
+}
+
+type SchemaDBChangeEvent struct {
+	Operation     string   `json:"operation"`
+	ID            string   `json:"id"`
+	Table         string   `json:"table"`
+	Key           []string `json:"key"`
+	ModelVersion  string   `json:"modelVersion"`
+	CompanyID     *string  `json:"companyId,omitempty"`
+	LocationID    *string  `json:"locationId,omitempty"`
+	UserID        *string  `json:"userId,omitempty"`
+	Before        any      `json:"before,omitempty"`
+	After         any      `json:"after,omitempty"`
+	Diff          []string `json:"diff,omitempty"`
+	Timestamp     int64    `json:"timestamp"`
+	MVCCTimestamp string   `json:"mvccTimestamp"`
+}
+
+func toSchemaDBChangeEvent(event internal.DBChangeEvent) (*SchemaDBChangeEvent, error) {
+	var before, after any
+	if event.Before != nil {
+		before = make(map[string]any)
+		if err := json.Unmarshal(event.Before, &before); err != nil {
+			return nil, fmt.Errorf("error unmarshalling before: %w", err)
+		}
+	}
+	if event.After != nil {
+		after = make(map[string]any)
+		if err := json.Unmarshal(event.After, &after); err != nil {
+			return nil, fmt.Errorf("error unmarshalling after: %w", err)
+		}
+	}
+	return &SchemaDBChangeEvent{
+		Operation:     event.Operation,
+		ID:            event.ID,
+		Table:         event.Table,
+		Key:           event.Key,
+		ModelVersion:  event.ModelVersion,
+		CompanyID:     event.CompanyID,
+		LocationID:    event.LocationID,
+		UserID:        event.UserID,
+		Before:        before,
+		After:         after,
+		Diff:          event.Diff,
+		Timestamp:     event.Timestamp,
+		MVCCTimestamp: event.MVCCTimestamp,
+	}, nil
+}
+
+// Validate validates the given event against the schema for the table. Returns true if a schema is found for the table, true if the event is valid, the path transformed and an error if one occurs.
+func (v *SchemaValidator) Validate(event internal.DBChangeEvent) (bool, bool, string, error) {
+	if rule, ok := v.rules[event.Table]; ok {
+		object, err := toSchemaDBChangeEvent(event)
+		if err != nil {
+			return true, false, "", fmt.Errorf("error converting to SchemaDBChangeEvent: %w", err)
+		}
+		o := make(map[string]any)
+		if err := json.Unmarshal([]byte(JSONStringify(object)), &o); err != nil {
+			return true, false, "", fmt.Errorf("error converting to SchemaDBChangeEvent: %w", err)
+		}
+		if err := rule.schema.Validate(o); err != nil {
+			if _, ok := err.(*js.ValidationError); ok {
+				return true, false, "", nil
+			}
+			return true, false, "", err
+		}
+		var path strings.Builder
+		if err := rule.template.Execute(&path, o); err != nil {
+			return true, false, "", fmt.Errorf("error executing template: %w for %s", err, JSONStringify(o))
+		}
+		return true, true, path.String(), nil
+	}
+	return false, false, "", nil
+}
+
+// NewSchemaValidator creates a new SchemaValidator from the schema files in the given directory.
+func NewSchemaValidator(schemaDir string) (*SchemaValidator, error) {
+
+	abs, err := filepath.Abs(schemaDir)
+	if err != nil {
+		return nil, fmt.Errorf("error getting absolute path for %s: %w", schemaDir, err)
+	}
+
+	config := filepath.Join(abs, "config.json")
+	if !Exists(config) {
+		return nil, fmt.Errorf("config.json not found in schema directory: %s", abs)
+	}
+
+	of, err := os.Open(config)
+	if err != nil {
+		return nil, fmt.Errorf("error opening %s: %w", config, err)
+	}
+	defer of.Close()
+
+	dec := json.NewDecoder(of)
+
+	rules := make(map[string]*SchemaValidationRule)
+
+	if err := dec.Decode(&rules); err != nil {
+		return nil, fmt.Errorf("error decoding config.json: %w", err)
+	}
+
+	compiler := js.NewCompiler()
+
+	files, err := ListDir(abs)
+	if err != nil {
+		return nil, fmt.Errorf("error listing files in %s: %w", abs, err)
+	}
+
+	// load up all of our schemas as resources so that they can be referenced
+	for _, filename := range files {
+		rel, _ := filepath.Rel(abs, filename)
+		if rel == "config.json" {
+			continue
+		}
+		buf, err := os.ReadFile(filename)
+		if err != nil {
+			return nil, fmt.Errorf("error reading: %s. %w", filename, err)
+		}
+		// load them in various url formats
+		if err := compiler.AddResource("file://"+rel, bytes.NewReader(buf)); err != nil {
+			return nil, fmt.Errorf("error adding schema: %s. %w", filename, err)
+		}
+		if err := compiler.AddResource("file:///"+rel, bytes.NewReader(buf)); err != nil {
+			return nil, fmt.Errorf("error adding schema: %s. %w", filename, err)
+		}
+		if err := compiler.AddResource("file://"+filename, bytes.NewReader(buf)); err != nil {
+			return nil, fmt.Errorf("error adding schema: %s. %w", filename, err)
+		}
+	}
+
+	for table, rule := range rules {
+		fn := filepath.Join(abs, rule.Schema)
+		if !Exists(fn) {
+			return nil, fmt.Errorf("schema file not found: %s for table: %s", fn, table)
+		}
+		schema, err := compiler.Compile("file://" + fn)
+		if err != nil {
+			return nil, fmt.Errorf("error compiling schema: %s for table: %s. %w", fn, table, err)
+		}
+		rule.schema = schema
+
+		tmpl, err := template.New(fn).Parse(rule.Path)
+		if err != nil {
+			return nil, fmt.Errorf("error creating template: %s for table: %s. %w", fn, table, err)
+		}
+		rule.template = tmpl
+	}
+
+	return &SchemaValidator{
+		compiler: compiler,
+		rules:    rules,
+	}, nil
+}

--- a/internal/util/schema_test.go
+++ b/internal/util/schema_test.go
@@ -1,0 +1,36 @@
+package util
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/shopmonkeyus/eds-server/internal"
+	"github.com/stretchr/testify/assert"
+)
+
+func strPtr(val string) *string {
+	return &val
+}
+
+func TestLoadSchema(t *testing.T) {
+	validator, err := NewSchemaValidator("./testdata")
+	assert.NoError(t, err)
+	assert.NotNil(t, validator)
+	event := internal.DBChangeEvent{
+		Operation:     "UPDATE",
+		ID:            "999",
+		LocationID:    strPtr("123"),
+		CompanyID:     strPtr("456"),
+		UserID:        strPtr("789"),
+		Table:         "labor",
+		Before:        json.RawMessage(JSONStringify(map[string]any{"completed": false, "orderId": "1", "serviceId": "2", "id": "xxx123"})),
+		After:         json.RawMessage(JSONStringify(map[string]any{"completed": true, "orderId": "1", "serviceId": "2", "id": "xxx123"})),
+		Diff:          []string{"completed"},
+		MVCCTimestamp: "123456789",
+	}
+	found, valid, path, err := validator.Validate(event)
+	assert.NoError(t, err)
+	assert.True(t, found)
+	assert.True(t, valid)
+	assert.Equal(t, "labor/received/labor_123456789_999.json", path)
+}

--- a/internal/util/testdata/base/message.json
+++ b/internal/util/testdata/base/message.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "file:///base/message.json",
+  "title": "Shopmonkey Base Message",
+  "type": "object",
+  "properties": {
+    "operation": {
+      "description": "The type of database operation",
+      "type": "string",
+      "enum": ["INSERT", "UPDATE", "DELETE"]
+    },
+    "locationId": {
+      "description": "The SM identifier of the location",
+      "type": "string",
+      "minLength": 1
+    },
+    "userId": {
+      "description": "The SM identifier of the user",
+      "type": "string",
+      "minLength": 1
+    }
+  },
+  "required": ["operation", "locationId", "userId"]
+}

--- a/internal/util/testdata/config.json
+++ b/internal/util/testdata/config.json
@@ -1,0 +1,6 @@
+{
+  "labor": {
+    "schema": "labor_message.json",
+    "path": "{{.table}}/received/{{.table}}_{{.mvccTimestamp}}_{{.id}}.json"
+  }
+}

--- a/internal/util/testdata/labor_message.json
+++ b/internal/util/testdata/labor_message.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Shopmonkey Labor Message",
+  "type": "object",
+  "allOf": [{ "$ref": "file:///base/message.json" }],
+  "properties": {
+    "table": {
+      "description": "The type of message we received from SM",
+      "type": "string",
+      "const": "labor"
+    }
+  },
+
+  "required": ["table"],
+
+  "anyOf": [
+    {
+      "properties": {
+        "before": {
+          "$ref": "file:///models/labor.json"
+        },
+        "after": {
+          "allOf": [
+            { "$ref": "file:///models/labor.json" },
+            { "properties": { "completed": { "const": true } } }
+          ]
+        },
+        "diff": {
+          "description": "A list of modified fields within an UPDATE operation",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "contains": {
+            "anyOf": [{ "const": "completed" }]
+          }
+        }
+      },
+      "required": ["before", "after", "diff"]
+    }
+  ]
+}

--- a/internal/util/testdata/models/labor.json
+++ b/internal/util/testdata/models/labor.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "file:///models/labor.json",
+  "title": "Shopmonkey Labor Model",
+  "type": "object",
+  "properties": {
+    "orderId": {
+      "description": "The SM identifier of the repair order",
+      "type": "string",
+      "minLength": 1
+    },
+    "serviceId": {
+      "description": "The SM identifier of the service",
+      "type": "string",
+      "minLength": 1
+    },
+    "id": {
+      "description": "The SM identifier of the SM labor",
+      "type": "string",
+      "minLength": 1
+    },
+    "completed": {
+      "description": "Checks if the editing of labor completed",
+      "type": "boolean"
+    }
+  },
+
+  "required": ["orderId", "serviceId", "id", "completed"]
+}


### PR DESCRIPTION
Initial implementation of using a JSON schema to validate both import and event processing.

Set using `--schema-validator`

Example:

```
go run . import --url "s3://localhost:4566/test" --schema-validator ./datadir/schema --api-key $TOKEN  --verbose --data-dir ./datadir
```

Create a folder schema with the following:

```json
{
  "labor": {
    "schema": "labor_message.json",
    "path": "{{.table}}/received/{{.table}}_{{.mvccTimestamp}}_{{.id}}.json"
  },
  "message": {
    "schema": "base/message.json",
    "path": "{{.table}}/received/{{.table}}_{{.mvccTimestamp}}_{{.id}}.json"
  }
}
```

And copy the test files from `./internal/util/testdata` into this folder