### PR TITLE
S3 improvements, masking improvements, fix SQL Server impl

### DIFF
--- a/internal/drivers/sqlserver/sqlserver.go
+++ b/internal/drivers/sqlserver/sqlserver.go
@@ -115,8 +115,8 @@ func (p *sqlserverDriver) Process(logger logger.Logger, event internal.DBChangeE
 }
 
 // Flush is called to commit any pending events. It should return an error if the flush fails. If the flush fails, the driver will NAK all pending events.
-func (p *sqlserverDriver) Flush() error {
-	p.logger.Debug("flush")
+func (p *sqlserverDriver) Flush(logger logger.Logger) error {
+	logger.Debug("flush")
 	p.waitGroup.Add(1)
 	defer p.waitGroup.Done()
 	if p.count > 0 {
@@ -131,7 +131,7 @@ func (p *sqlserverDriver) Flush() error {
 			}
 		}()
 		if _, err := tx.ExecContext(p.ctx, p.pending.String()); err != nil {
-			p.logger.Trace("offending sql: %s", p.pending.String())
+			logger.Trace("offending sql: %s", p.pending.String())
 			return fmt.Errorf("unable to execute sql: %w", err)
 		}
 		if err := tx.Commit(); err != nil {

--- a/internal/util/mask.go
+++ b/internal/util/mask.go
@@ -3,6 +3,7 @@ package util
 import (
 	"fmt"
 	"net/url"
+	"sort"
 	"strings"
 
 	cstr "github.com/shopmonkeyus/go-common/string"
@@ -34,10 +35,14 @@ func MaskURL(urlString string) (string, error) {
 			str.WriteString(cstr.Mask(p[1:]))
 		}
 	}
-	qs := u.Query().Encode()
-	if qs != "" {
+	var qs []string
+	for k, v := range u.Query() {
+		qs = append(qs, fmt.Sprintf("%s=%s", k, cstr.Mask(strings.Join(v, ","))))
+	}
+	sort.Strings(qs)
+	if len(qs) > 0 {
 		str.WriteString("?")
-		str.WriteString(cstr.Mask(qs))
+		str.WriteString(strings.Join(qs, "&"))
 	}
 	return str.String(), nil
 }

--- a/internal/util/mask_test.go
+++ b/internal/util/mask_test.go
@@ -9,9 +9,13 @@ import (
 func TestMaskUrl(t *testing.T) {
 	u, err := MaskURL("http://user:password@localhost:8080/path?query=1")
 	assert.NoError(t, err)
-	assert.Equal(t, "http://us**:pass****@localhost:8080/pa**?que****", u)
+	assert.Equal(t, "http://us**:pass****@localhost:8080/pa**?query=*", u)
 
 	u, err = MaskURL("snowflake://FOO:thisisapassword@TFLXCJY-LU41011/TEST/PUBLIC")
 	assert.NoError(t, err)
 	assert.Equal(t, "snowflake://F**:thisisa********@TFLXCJY-LU41011/TEST/******", u)
+
+	u, err = MaskURL("s3://bucket/folder?region=us-west-2&access-key-id=AKIAIOSFODNN7EXAMPLE&secret-access-key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+	assert.NoError(t, err)
+	assert.Equal(t, "s3://bucket/fol***?access-key-id=AKIAIOSFOD**********&region=us-w*****&secret-access-key=wJalrXUtnFEMI/K7MDEN********************", u)
 }


### PR DESCRIPTION
# S3 Driver:

- improve driver by allowing config to be set in url
- fix occasional panic on shutdown

url example with config:

```
s3://bucket/folder?region=us-west-2&access-key-id=AKIAIOSFODNN7EXAMPLE&secret-access-key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
```

# SQL Server

- fix build issue with Flush signature change

# Misc

- improve masking to only mask query string values instead of the keys