### PR TITLE
[VCARB-136] add test case for JSON schema validation with format support and improve schema validation issue

### DIFF
--- a/internal/util/schema.go
+++ b/internal/util/schema.go
@@ -88,8 +88,8 @@ func (v *SchemaValidator) Validate(event internal.DBChangeEvent) (bool, bool, st
 			return true, false, "", fmt.Errorf("error converting to SchemaDBChangeEvent: %w", err)
 		}
 		if err := rule.schema.Validate(o); err != nil {
-			if _, ok := err.(*js.ValidationError); ok {
-				return true, false, "", nil
+			if verr, ok := err.(*js.ValidationError); ok {
+				return true, false, "", verr
 			}
 			return true, false, "", err
 		}

--- a/internal/util/schema_test.go
+++ b/internal/util/schema_test.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"encoding/json"
+	"regexp"
 	"testing"
 
 	"github.com/shopmonkeyus/eds-server/internal"
@@ -23,8 +24,8 @@ func TestLoadSchema(t *testing.T) {
 		CompanyID:     strPtr("456"),
 		UserID:        strPtr("789"),
 		Table:         "labor",
-		Before:        json.RawMessage(JSONStringify(map[string]any{"completed": false, "orderId": "1", "serviceId": "2", "id": "xxx123"})),
-		After:         json.RawMessage(JSONStringify(map[string]any{"completed": true, "orderId": "1", "serviceId": "2", "id": "xxx123"})),
+		Before:        json.RawMessage(JSONStringify(map[string]any{"completed": false, "orderId": "1", "serviceId": "2", "id": "xxx123", "startDate": "2021-01-01T00:00:00Z"})),
+		After:         json.RawMessage(JSONStringify(map[string]any{"completed": true, "orderId": "1", "serviceId": "2", "id": "xxx123", "startDate": "2021-01-01T00:00:00Z"})),
 		Diff:          []string{"completed"},
 		MVCCTimestamp: "123456789",
 	}
@@ -33,4 +34,30 @@ func TestLoadSchema(t *testing.T) {
 	assert.True(t, found)
 	assert.True(t, valid)
 	assert.Equal(t, "labor/received/labor_123456789_999.json", path)
+}
+
+func TestLoadSchemaDateInvalid(t *testing.T) {
+	validator, err := NewSchemaValidator("./testdata")
+	assert.NoError(t, err)
+	assert.NotNil(t, validator)
+	event := internal.DBChangeEvent{
+		Operation:     "UPDATE",
+		ID:            "999",
+		LocationID:    strPtr("123"),
+		CompanyID:     strPtr("456"),
+		UserID:        strPtr("789"),
+		Table:         "labor",
+		Before:        json.RawMessage(JSONStringify(map[string]any{"completed": false, "orderId": "1", "serviceId": "2", "id": "xxx123", "startDate": "2021-01-01T00:00:00Z"})),
+		After:         json.RawMessage(JSONStringify(map[string]any{"completed": true, "orderId": "1", "serviceId": "2", "id": "xxx123", "startDate": "x2021-01-01T00:00:00Z"})),
+		Diff:          []string{"completed"},
+		MVCCTimestamp: "123456789",
+	}
+	found, valid, path, err := validator.Validate(event)
+	assert.Error(t, err)
+	m, err := regexp.MatchString(`jsonschema: '\/after\/startDate' does not validate with file:\/\/(.*)?\/testdata\/labor_message\.json#\/anyOf\/0\/properties\/after\/allOf\/0\/\$ref\/properties\/startDate\/format: 'x2021-01-01T00:00:00Z' is not valid 'date-time'`, err.Error())
+	assert.NoError(t, err)
+	assert.True(t, m)
+	assert.True(t, found)
+	assert.False(t, valid)
+	assert.Empty(t, path)
 }

--- a/internal/util/testdata/models/labor.json
+++ b/internal/util/testdata/models/labor.json
@@ -22,8 +22,13 @@
     "completed": {
       "description": "Checks if the editing of labor completed",
       "type": "boolean"
+    },
+    "startDate": {
+      "description": "The start datetime",
+      "type": "string",
+      "format": "date-time"
     }
   },
 
-  "required": ["orderId", "serviceId", "id", "completed"]
+  "required": ["orderId", "serviceId", "id", "completed", "startDate"]
 }


### PR DESCRIPTION
Looks like the json schema library we support works with a number of json schema formats out of the box. This PR adds a test case to validate their usage and also improves the error message when a schema validation fails.