### PR TITLE
[VCARB-140] add configuration import

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -430,12 +430,12 @@ var importCmd = &cobra.Command{
 		driver, err := internal.NewDriverForImport(ctx, logger, driverUrl, registry, nil, dataDir)
 		if err != nil {
 			fmt.Println(err.Error())
-			os.Exit(3) /// this means the test failed
+			os.Exit(3) // this means the test failed
 		}
 		timedCtx, timedCancel := context.WithTimeout(ctx, 15*time.Second)
 		if err := driver.Test(timedCtx, logger, driverUrl); err != nil {
 			fmt.Println(err.Error())
-			os.Exit(3) /// this means the test failed
+			os.Exit(3) // this means the test failed
 		}
 		timedCancel()
 		logger.Debug("driver test successful")

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -370,6 +370,7 @@ var importCmd = &cobra.Command{
 		jobID := mustFlagString(cmd, "job-id", false)
 		single, _ := cmd.Flags().GetBool("single")
 		dir := mustFlagString(cmd, "dir", false)
+		schemaOnly := mustFlagBool(cmd, "schema-only", false)
 
 		logger := newLogger(cmd)
 		logger = logger.WithPrefix("[import]")
@@ -425,6 +426,21 @@ var importCmd = &cobra.Command{
 			logger.Fatal("error creating registry: %s", err)
 		}
 
+		// create the driver for testing the connection
+		driver, err := internal.NewDriverForImport(ctx, logger, driverUrl, registry, nil, dataDir)
+		if err != nil {
+			fmt.Println(err.Error())
+			os.Exit(3) /// this means the test failed
+		}
+		timedCtx, timedCancel := context.WithTimeout(ctx, 15*time.Second)
+		if err := driver.Test(timedCtx, logger, driverUrl); err != nil {
+			fmt.Println(err.Error())
+			os.Exit(3) /// this means the test failed
+		}
+		timedCancel()
+		logger.Debug("driver test successful")
+		// NOTE: we don't stop the driver here since we need it for the importer
+
 		// save the new schema file
 		if err := registry.Save(schemaFile); err != nil {
 			logger.Fatal("error saving schema: %s", err)
@@ -446,7 +462,7 @@ var importCmd = &cobra.Command{
 			skipDeleteConfirm = !importerHelp.SupportsDelete()
 		}
 
-		if !dryRun && !noconfirm && !skipDeleteConfirm {
+		if !dryRun && !noconfirm && !skipDeleteConfirm && !schemaOnly {
 
 			meta, err := internal.GetDriverMetadataForURL(driverUrl)
 			if err != nil {
@@ -514,62 +530,84 @@ var importCmd = &cobra.Command{
 		defer util.RecoverPanic(logger) // panic recover needs to happen after the defer above
 
 		if dir == "" {
-			if jobID == "" {
-				logger.Info("Requesting Export...")
-				jobID, err = createExportJob(ctx, apiURL, apiKey, exportJobCreateRequest{
-					Tables:      only,
-					CompanyIDs:  companyIds,
-					LocationIDs: locationIds,
-				})
-				if err != nil {
-					logger.Error("error creating export job: %s", err)
+			if !schemaOnly {
+				if jobID == "" {
+					logger.Info("Requesting Export...")
+					jobID, err = createExportJob(ctx, apiURL, apiKey, exportJobCreateRequest{
+						Tables:      only,
+						CompanyIDs:  companyIds,
+						LocationIDs: locationIds,
+					})
+					if err != nil {
+						logger.Fatal("error creating export job: %s", err)
+					}
+					logger.Trace("created job: %s", jobID)
+				}
+
+				logger.Info("Waiting for Export to Complete...")
+				job, err := pollUntilComplete(ctx, logger, apiURL, apiKey, jobID)
+				if err != nil && !isCancelled(ctx) {
+					logger.Fatal("error polling job: %s", err)
+				}
+
+				if isCancelled(ctx) {
 					return
 				}
-				logger.Trace("created job: %s", jobID)
-			}
 
-			logger.Info("Waiting for Export to Complete...")
-			job, err := pollUntilComplete(ctx, logger, apiURL, apiKey, jobID)
-			if err != nil && !isCancelled(ctx) {
-				logger.Error("error polling job: %s", err)
-				return
-			}
+				// download the files
+				dir, err = os.MkdirTemp(dataDir, "import-"+jobID+"-*")
+				if err != nil {
+					logger.Fatal("error creating temp dir: %s", err)
+				}
+				logger.Trace("temp dir created: %s", dir)
 
-			if isCancelled(ctx) {
-				return
-			}
+				logger.Info("Downloading export data...")
+				tableData, err := bulkDownloadData(logger, job.Tables, dir)
+				if err != nil {
+					logger.Fatal("error downloading files: %s", err)
+				}
 
-			// download the files
-			dir, err = os.MkdirTemp(dataDir, "import-"+jobID+"-*")
-			if err != nil {
-				logger.Error("error creating temp dir: %s", err)
-				return
-			}
-			logger.Trace("temp dir created: %s", dir)
+				if isCancelled(ctx) {
+					return
+				}
 
-			logger.Info("Downloading export data...")
-			tableData, err := bulkDownloadData(logger, job.Tables, dir)
-			if err != nil {
-				logger.Error("error downloading files: %s", err)
-				return
+				to, err := os.Create(filepath.Join(dir, "tables.json"))
+				if err != nil {
+					logger.Fatal("couldn't open temp tables file: %s", err)
+				}
+				enc := json.NewEncoder(to)
+				if err := enc.Encode(tableData); err != nil {
+					logger.Fatal("error encoding tables: %s", err)
+				}
+				to.Close()
+				tables = tableNames(tableData)
+			} else {
+				logger.Debug("schema only, skipping download")
+				// we need to manually create all the tables in this specific case since we are --schema-only
+				schema, err := registry.GetLatestSchema()
+				if err != nil {
+					logger.Fatal("error getting latest schema: %s", err)
+				}
+				to, err := os.Create(filepath.Join(dir, "tables.json"))
+				if err != nil {
+					logger.Fatal("couldn't open temp tables file: %s", err)
+					return
+				}
+				time := time.Now()
+				var tableData []TableExportInfo
+				for _, data := range schema {
+					tableData = append(tableData, TableExportInfo{
+						Table:     data.Table,
+						Timestamp: time,
+					})
+				}
+				enc := json.NewEncoder(to)
+				if err := enc.Encode(tableData); err != nil {
+					logger.Fatal("error encoding tables: %s", err)
+				}
+				to.Close()
+				tables = tableNames(tableData)
 			}
-
-			if isCancelled(ctx) {
-				return
-			}
-
-			to, err := os.Create(filepath.Join(dir, "tables.json"))
-			if err != nil {
-				logger.Error("couldn't open temp tables file: %s", err)
-				return
-			}
-			enc := json.NewEncoder(to)
-			if err := enc.Encode(tableData); err != nil {
-				logger.Error("error encoding tables: %s", err)
-				return
-			}
-			to.Close()
-			tables = tableNames(tableData)
 		} else {
 			fp := filepath.Join(dir, "tables.json")
 			tableData, err := loadTablesJSON(fp)
@@ -603,6 +641,7 @@ var importCmd = &cobra.Command{
 			Tables:          tables,
 			Single:          single,
 			SchemaValidator: validator,
+			SchemaOnly:      schemaOnly,
 		}); err != nil {
 			logger.Error("error running import: %s", err)
 			return
@@ -625,6 +664,7 @@ func init() {
 	importCmd.Flags().Bool("no-confirm", false, "skip the confirmation prompt")
 	importCmd.Flags().Bool("no-cleanup", false, "skip removing the temp directory")
 	importCmd.Flags().String("dir", "", "restart reading files from this existing import directory instead of downloading again")
+	importCmd.Flags().Bool("schema-only", false, "run the schema creation only, skipping the data import")
 
 	// tuning and testing flags
 	importCmd.Flags().Int("parallel", 4, "the number of parallel upload tasks (if supported by driver)")

--- a/internal/drivers/eventhub/eventhub.go
+++ b/internal/drivers/eventhub/eventhub.go
@@ -233,6 +233,9 @@ func (p *eventHubDriver) ImportCompleted() error {
 }
 
 func (p *eventHubDriver) Import(config internal.ImporterConfig) error {
+	if config.SchemaOnly {
+		return nil
+	}
 	p.logger = config.Logger.WithPrefix("[eventhub]")
 	if err := p.connect(config.URL); err != nil {
 		return err
@@ -247,6 +250,14 @@ func (p *eventHubDriver) Import(config internal.ImporterConfig) error {
 // SupportsDelete returns true if the importer supports deleting data.
 func (p *eventHubDriver) SupportsDelete() bool {
 	return false
+}
+
+// Test is called to test the drivers connectivity with the configured url. It should return an error if the test fails or nil if the test passes.
+func (p *eventHubDriver) Test(ctx context.Context, logger logger.Logger, url string) error {
+	if err := p.connect(url); err != nil {
+		return err
+	}
+	return p.producer.Close(context.Background())
 }
 
 func init() {

--- a/internal/drivers/file/file.go
+++ b/internal/drivers/file/file.go
@@ -1,6 +1,7 @@
 package file
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"os"
@@ -151,6 +152,9 @@ func (p *fileDriver) ImportCompleted() error {
 }
 
 func (p *fileDriver) Import(config internal.ImporterConfig) error {
+	if config.SchemaOnly {
+		return nil
+	}
 	p.logger = config.Logger.WithPrefix("[file]")
 	if _, err := p.GetPathFromURL(config.URL); err != nil {
 		return err
@@ -162,6 +166,12 @@ func (p *fileDriver) Import(config internal.ImporterConfig) error {
 // SupportsDelete returns true if the importer supports deleting data.
 func (p *fileDriver) SupportsDelete() bool {
 	return false
+}
+
+// Test is called to test the drivers connectivity with the configured url. It should return an error if the test fails or nil if the test passes.
+func (p *fileDriver) Test(ctx context.Context, logger logger.Logger, url string) error {
+	_, err := p.GetPathFromURL(url)
+	return err
 }
 
 func init() {

--- a/internal/drivers/kafka/kafka.go
+++ b/internal/drivers/kafka/kafka.go
@@ -208,6 +208,9 @@ func (p *kafkaDriver) ImportCompleted() error {
 }
 
 func (p *kafkaDriver) Import(config internal.ImporterConfig) error {
+	if config.SchemaOnly {
+		return nil
+	}
 	p.logger = config.Logger.WithPrefix("[kafka]")
 	p.ctx = config.Context
 	p.importConfig = config
@@ -220,6 +223,14 @@ func (p *kafkaDriver) Import(config internal.ImporterConfig) error {
 // SupportsDelete returns true if the importer supports deleting data.
 func (p *kafkaDriver) SupportsDelete() bool {
 	return false
+}
+
+// Test is called to test the drivers connectivity with the configured url. It should return an error if the test fails or nil if the test passes.
+func (p *kafkaDriver) Test(ctx context.Context, logger logger.Logger, url string) error {
+	if err := p.connect(url); err != nil {
+		return err
+	}
+	return p.writer.Close()
 }
 
 func init() {

--- a/internal/drivers/mysql/mysql.go
+++ b/internal/drivers/mysql/mysql.go
@@ -229,6 +229,15 @@ func (p *mysqlDriver) Help() string {
 	return help.String()
 }
 
+// Test is called to test the drivers connectivity with the configured url. It should return an error if the test fails or nil if the test passes.
+func (p *mysqlDriver) Test(ctx context.Context, logger logger.Logger, url string) error {
+	db, err := p.connectToDB(ctx, url)
+	if err != nil {
+		return err
+	}
+	return db.Close()
+}
+
 func init() {
 	var driver mysqlDriver
 	internal.RegisterDriver("mysql", &driver)

--- a/internal/drivers/postgresql/postgresql.go
+++ b/internal/drivers/postgresql/postgresql.go
@@ -166,6 +166,10 @@ func (p *postgresqlDriver) Import(config internal.ImporterConfig) error {
 		logger.Debug("created table %s", table)
 	}
 
+	if config.SchemaOnly {
+		return nil
+	}
+
 	files, err := util.ListDir(config.DataDir)
 	if err != nil {
 		return fmt.Errorf("unable to list dir: %w", err)
@@ -256,6 +260,15 @@ func (p *postgresqlDriver) Help() string {
 
 func (p *postgresqlDriver) Aliases() []string {
 	return []string{"postgresql"}
+}
+
+// Test is called to test the drivers connectivity with the configured url. It should return an error if the test fails or nil if the test passes.
+func (p *postgresqlDriver) Test(ctx context.Context, logger logger.Logger, url string) error {
+	db, err := p.connectToDB(ctx, url)
+	if err != nil {
+		return err
+	}
+	return db.Close()
 }
 
 func init() {

--- a/internal/drivers/snowflake/snowflake.go
+++ b/internal/drivers/snowflake/snowflake.go
@@ -238,6 +238,10 @@ func (p *snowflakeDriver) Import(config internal.ImporterConfig) error {
 		logger.Debug("created table %s", table)
 	}
 
+	if config.SchemaOnly {
+		return nil
+	}
+
 	// create a stage
 	stageName := "eds_import_" + config.JobID
 	logger.Debug("creating stage %s", stageName)
@@ -330,6 +334,15 @@ func (p *snowflakeDriver) Help() string {
 	var help strings.Builder
 	help.WriteString(util.GenerateHelpSection("Schema", "The database will match the public schema from the Shopmonkey transactional database.\n"))
 	return help.String()
+}
+
+// Test is called to test the drivers connectivity with the configured url. It should return an error if the test fails or nil if the test passes.
+func (p *snowflakeDriver) Test(ctx context.Context, logger logger.Logger, url string) error {
+	db, err := p.connectToDB(ctx, url)
+	if err != nil {
+		return err
+	}
+	return db.Close()
 }
 
 func init() {

--- a/internal/drivers/sqlserver/sqlserver.go
+++ b/internal/drivers/sqlserver/sqlserver.go
@@ -229,6 +229,15 @@ func (p *sqlserverDriver) Help() string {
 	return help.String()
 }
 
+// Test is called to test the drivers connectivity with the configured url. It should return an error if the test fails or nil if the test passes.
+func (p *sqlserverDriver) Test(ctx context.Context, logger logger.Logger, url string) error {
+	db, err := p.connectToDB(ctx, url)
+	if err != nil {
+		return err
+	}
+	return db.Close()
+}
+
 func init() {
 	var driver sqlserverDriver
 	internal.RegisterDriver("sqlserver", &driver)

--- a/internal/importer.go
+++ b/internal/importer.go
@@ -44,6 +44,9 @@ type ImporterConfig struct {
 
 	// Single is true if only a single row should be imported at a time vs batching.
 	Single bool
+
+	// Only create the schema but do not import any data.
+	SchemaOnly bool
 }
 
 // Importer is the interface that must be implemented by all importer implementations

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -36,6 +36,9 @@ func Run(logger logger.Logger, config internal.ImporterConfig, handler Handler) 
 	if err := handler.CreateDatasource(schema); err != nil {
 		return err
 	}
+	if config.SchemaOnly {
+		return nil
+	}
 	var total int
 	for _, file := range files {
 		table, tv, ok := util.ParseCRDBExportFile(file)


### PR DESCRIPTION
Adds end-to-end configure url and import logic.  Also refactors the Driver interface to be able to test the connection url.

NOTE: in a subsequent PR going to separate out the configure / import messages but this is a good first iteration for end-to-end testing in the app.


Requires https://github.com/shopmonkeyus/backend/pull/7213 for import on configure to work